### PR TITLE
Fix some incorrect error messages.

### DIFF
--- a/src/pull.go
+++ b/src/pull.go
@@ -34,7 +34,7 @@ func (f *PullFlags) Init(cmd *cobra.Command) {
 func (f *PullFlags) Validate() Validations {
 	var validations Validations
 	if !f.HasAtLeastOneRepoFlag() {
-		validations = append(validations, "one of -repo-name, -repo-name-list, -repo-name-list-file must be set")
+		validations = append(validations, "one of --repo-name, --repo-name-list, --repo-name-list-file must be set")
 	}
 	return validations
 }

--- a/src/push.go
+++ b/src/push.go
@@ -30,10 +30,10 @@ func (f *PushFlags) Init(cmd *cobra.Command) {
 func (f *PushFlags) Validate() Validations {
 	var validations Validations
 	if f.BaseURL == "" {
-		validations = append(validations, "-baseURL must be set")
+		validations = append(validations, "--destination-url must be set")
 	}
 	if f.Token == "" {
-		validations = append(validations, "-token must be set")
+		validations = append(validations, "--destination-token must be set")
 	}
 	return validations
 }


### PR DESCRIPTION
`f.Token` is provided by the command line argument `--destination-token`, not `-token`.

`f.BaseURL` is likewise provided by `--destination-url`, not `-baseURL`.

(Although some Go accept long single-dashed arguments it seems like Cobra does not so I've also updated messages with single dashed arguments to use double-dashed arguments.)