### PR TITLE
Fix `--cache-dir` not actually being marked as a required flag.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,7 +86,7 @@ var (
 
 func Execute(ctx context.Context) error {
 	rootCmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", "", "Directory containing the repopositories cache created by the `pull` command")
-	_ = rootCmd.MarkFlagRequired("cache-dir")
+	_ = rootCmd.MarkPersistentFlagRequired("cache-dir")
 
 	rootCmd.AddCommand(versionCmd)
 


### PR DESCRIPTION
`cache-dir` is a persistent flag so the method `MarkPersistentFlagRequired` is required to mark it as required.

It is currently possible to invoke the tool without passing `--cache-dir` at all which results in the confusing error message `stat : no such file or directory`.