### PR TITLE
Swap to environment files

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: 1.14
       - name: Set CURRENT_TAG
-        run: echo ::set-env name=GORELEASER_CURRENT_TAG::${GITHUB_REF#refs/tags/}
+        run: echo "GORELEASER_CURRENT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
The newest toolkit version uses [Environment files](https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files) to communicate with the Runner. This pr moves towards the new way of communicating with the runner and updates the toolkit version if appropriate.