### PR TITLE
Mention the workflow scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ When no machine has access to both the public internet and the GHES instance:
 
 ## Destination token scopes
 
-When creating a personal access token include the `repo` scope. Include the `site_admin` scope (optional) if you want organizations to be created as necessary.
+When creating a personal access token include the `repo` the `workflow` scope. Include the `site_admin` scope (optional) if you want organizations to be created as necessary.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ When no machine has access to both the public internet and the GHES instance:
 
 ## Destination token scopes
 
-When creating a personal access token include the `repo` the `workflow` scope. Include the `site_admin` scope (optional) if you want organizations to be created as necessary.
+When creating a personal access token include the `repo` and `workflow` scopes. Include the `site_admin` scope (optional) if you want organizations to be created as necessary.
 
 ## Contributing
 


### PR DESCRIPTION
If there's a change in the `.github/workflows` directory, running `actions-sync` fails with the following message:

```
$ ./bin/actions-sync sync --cache-dir cache --destination-token "[token]" --destination-url "https://[hostname]" --repo-name actions/setup-python
fetching * refs for actions/setup-python ...
syncing `actions/setup-python`
error syncing repository `actions/setup-python`: failed to push to repo: https://[hostname]/actions/setup-python.git: command error on refs/heads/main: refusing to allow a Personal Access Token to create or update workflow `.github/workflows/codeql-analysis.yml` without `workflow` scope
```

This PR updates the README.md to mention that the `workflow` scope is also required.