### PR TITLE
update go version to 1.16 to fix the CI build

### DIFF
--- a/Dockerfile.cibuild
+++ b/Dockerfile.cibuild
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.16
 
 ENV GO111MODULE=on
 WORKDIR /go/src/github.com/actions/actions-sync


### PR DESCRIPTION
We need latest golang version to fix the CI build.

Failed build:
https://github.com/actions/actions-sync/runs/4740833795?check_suite_focus=true
```code
/go/pkg/mod/github.com/fzipp/gocyclo@v0.4.0/analyze.go:12:2: package io/fs is not in GOROOT (/usr/local/go/src/io/fs)
Service 'lint' failed to build : The command '/bin/sh -c script/bootstrap' returned a non-zero code: 1
```

Successful build with latest version:
https://github.com/actions/actions-sync/runs/4740948264?check_suite_focus=true