### PR TITLE
Bringing CI back on fix bootstrap and lint script

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,7 +28,7 @@ fi
 
 if [ ! -f "${GOBIN}/golangci-lint" ]; then
     echo "golangci was not found, installing..."
-    go get github.com/golangci/golangci-lint/cmd/golangci-lint@master
+    curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.45.2
 fi
 
 if [ ! -f "${GOBIN}/goimports" ]; then

--- a/script/lint
+++ b/script/lint
@@ -7,4 +7,4 @@ test -z "${DEBUG:-}" || {
     set -x
 }
 
-_tools/bin/golangci-lint run --config .golangci.yaml
+golangci-lint run --config .golangci.yaml


### PR DESCRIPTION
## Why?

CI workflow is currently broken. This change should bring it back.

## How?

Root cause: installation pattern for `golangci-lint` seems to be broken. 
Used recommended installation from official docs: https://golangci-lint.run/usage/install/#other-ci
Remark: now pins the used version of the linter -> should be fine
