### PR TITLE
Fixing cross site scripting codescan alert

### DIFF
--- a/test/github.go
+++ b/test/github.go
@@ -159,7 +159,7 @@ func main() {
 
 		if repoName != existingRepo {
 			w.WriteHeader(http.StatusNotFound)
-			_, err := w.Write([]byte(fmt.Sprintf("Repo %s not found", repoName)))
+			_, err := w.Write([]byte(fmt.Sprintf("Repo %s not found", html.EscapeString(repoName))))
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
We have a codescan alert:
https://github.com/actions/actions-sync/security/code-scanning/5

Recommendation fix:
To guard against cross-site scripting, consider using contextual output encoding/escaping before writing user input to the response, or one of the other solutions that are mentioned in the references.

```
// BAD: a request parameter is incorporated without validation into the response
fmt.Fprintf(w, "%q is an unknown user", username)
```
```
// GOOD: a request parameter is escaped before being put into the response
fmt.Fprintf(w, "%q is an unknown user", html.EscapeString(username))
```

Hence wrapping with html escape string function.