### PR TITLE
Fix go release workflow by updating to latest version

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -14,13 +14,11 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up Go 1.14
-        uses: actions/setup-go@v2-beta
-        with:
-          go-version: 1.14
+        uses: actions/setup-go@v3
       - name: Set CURRENT_TAG
         run: echo "GORELEASER_CURRENT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
           args: release --rm-dist


### PR DESCRIPTION
While testing the release process, faced issue when run with `actions/setup-go@v2-beta`

```code

Error: Unable to process command '::set-env name=GOROOT::/opt/hostedtoolcache/go/1.14.15/x64' successfully.
Error: The `set-env` command is disabled. Please upgrade to using Environment Files or opt into unsecure command execution by setting the `ACTIONS_ALLOW_UNSECURE_COMMANDS` environment variable to `true`. 
For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

```

https://github.com/ajaykn-org/actions-sync/runs/6565540369?check_suite_focus=true

<img width="1792" alt="CleanShot 2022-05-24 at 12 30 50@2x" src="https://user-images.githubusercontent.com/40024974/169968736-d207d6e8-af0f-4504-8557-c64789aafd7a.png">

Updating to latest has fixed the issue.
working: https://github.com/ajaykn-org/actions-sync/actions/runs/2374920393

relates: https://github.com/github/c2c-actions-policy/issues/439