### PR TITLE
Add actions admin user impersonation via a --actions-admin-user flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _tools/bin
 bin
 test/tmp
 dist
+actions-sync

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When there are machines which have access to both the public internet and the GH
 **Arguments:**
 
 - `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. If not specified `actions-admin` will be used. To disable the impersonation pass `-` as the value.
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled.
 - `cache-dir` _(required)_
    The directory in which to cache repositories as they are synced. This speeds up re-syncing.
 - `destination-url` _(required)_
@@ -87,7 +87,7 @@ When no machine has access to both the public internet and the GHES instance:
 **Arguments:**
 
 - `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. If not specified `actions-admin` will be used. To disable the impersonation pass `-` as the value.
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled.
 - `cache-dir` _(required)_
    The directory containing the repositories fetched using the `pull` command.
 - `destination-url` _(required)_

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ When there are machines which have access to both the public internet and the GH
 **Arguments:**
 
 - `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled.
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `cache-dir` _(required)_
    The directory in which to cache repositories as they are synced. This speeds up re-syncing.
 - `destination-url` _(required)_
@@ -87,7 +87,7 @@ When no machine has access to both the public internet and the GHES instance:
 **Arguments:**
 
 - `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled.
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `cache-dir` _(required)_
    The directory containing the repositories fetched using the `pull` command.
 - `destination-url` _(required)_
@@ -108,7 +108,7 @@ When no machine has access to both the public internet and the GHES instance:
 
 ## Destination token scopes
 
-When creating a personal access token include the `repo` and `workflow` scopes. Include the `site_admin` scope (optional) if you want organizations to be created as necessary.
+When creating a personal access token include the `repo` and `workflow` scopes. Include the `site_admin` scope (optional) if you want organizations to be created as necessary or you want to use the impersonation logic for the `push` or `sync` commands.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ When there are machines which have access to both the public internet and the GH
 
 **Arguments:**
 
+- `actions-admin-user` _(optional)_
+   The name of the Actions admin user, which will be used for updating the chosen action. If not specified `actions-admin` will be used. To disable the impersonation pass `-` as the value.
 - `cache-dir` _(required)_
    The directory in which to cache repositories as they are synced. This speeds up re-syncing.
 - `destination-url` _(required)_
@@ -84,6 +86,8 @@ When no machine has access to both the public internet and the GHES instance:
 
 **Arguments:**
 
+- `actions-admin-user` _(optional)_
+   The name of the Actions admin user, which will be used for updating the chosen action. If not specified `actions-admin` will be used. To disable the impersonation pass `-` as the value.
 - `cache-dir` _(required)_
    The directory containing the repositories fetched using the `pull` command.
 - `destination-url` _(required)_

--- a/src/push.go
+++ b/src/push.go
@@ -39,7 +39,7 @@ func (f *PushFlags) Init(cmd *cobra.Command) {
 
 func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.BaseURL, "destination-url", "", "URL of GHES instance")
-	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "", "A user to impersonate for the push requests. To use the default name, pass 'actions-admin'.")
+	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "", "A user to impersonate for the push requests. To use the default name, pass 'actions-admin'. Note that the site_admin scope in the token is required for the impersonation to work.")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
 }

--- a/src/push.go
+++ b/src/push.go
@@ -17,9 +17,14 @@ import (
 	"golang.org/x/oauth2"
 )
 
+const enterpriseAegisVersionHeaderValue = "GitHub AE"
+const enterpriseAPIPath = "/api/v3"
+const enterpriseVersionHeaderKey = "X-GitHub-Enterprise-Version"
+const xOAuthScopesHeader = "X-OAuth-Scopes"
+
 type PushOnlyFlags struct {
-	BaseURL, Token string
-	DisableGitAuth bool
+	BaseURL, Token, ActionsAdminUser string
+	DisableGitAuth                   bool
 }
 
 type PushFlags struct {
@@ -34,6 +39,7 @@ func (f *PushFlags) Init(cmd *cobra.Command) {
 
 func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.BaseURL, "destination-url", "", "URL of GHES instance")
+	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "actions-admin", "The name of the Actions admin user. Pass '-' to disable the impersonation")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
 }
@@ -53,7 +59,62 @@ func (f *PushOnlyFlags) Validate() Validations {
 	return validations
 }
 
+func GetImpersonationToken(ctx context.Context, flags *PushFlags) (string, error) {
+	fmt.Printf("Getting an impersonation token for `%s`..\n", flags.ActionsAdminUser)
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: flags.Token})
+	tc := oauth2.NewClient(ctx, ts)
+	ghClient, err := github.NewEnterpriseClient(flags.BaseURL, flags.BaseURL, tc)
+	if err != nil {
+		return "", errors.Wrap(err, "error creating enterprise client")
+	}
+
+	rootRequest, err := ghClient.NewRequest("GET", enterpriseAPIPath, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "Error constructing request for GitHub Enterprise client.")
+	}
+	rootResponse, err := ghClient.Do(ctx, rootRequest, nil)
+	if err != nil {
+		return "", errors.Wrap(err, "Error checking connectivity for GitHub Enterprise client.")
+	}
+
+	scopesHeader := rootResponse.Header.Get(xOAuthScopesHeader)
+	fmt.Printf("These are the scopes we have for the current token `%s`..\n", scopesHeader)
+
+	isAE := rootResponse.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue
+	minimumRepositoryScope := "public_repo"
+	if isAE {
+		// the default repository scope for non-ae instances is 'public_repo'
+		// while it is `repo` for ae.
+		minimumRepositoryScope = "repo"
+		fmt.Printf("Running against GitHub AE, changing the repository scope to '%s'..\n", minimumRepositoryScope)
+	} else {
+		if !strings.Contains(scopesHeader, "site_admin") {
+			fmt.Printf("The current token doesn't have the `site_admin` scope. The impersonation request for GHES requres the `site_admin` permission to be able to impersonate. For GitHub AE it's not required.")
+		}
+	}
+
+	impersonationToken, _, err := ghClient.Admin.CreateUserImpersonation(ctx, flags.ActionsAdminUser, &github.ImpersonateUserOptions{Scopes: []string{minimumRepositoryScope, "workflow"}})
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to impersonate Actions admin user.")
+	}
+
+	fmt.Printf("Got the impersonation token for `%s`..\n", flags.ActionsAdminUser)
+
+	return impersonationToken.GetToken(), nil
+}
+
 func Push(ctx context.Context, flags *PushFlags) error {
+	if flags.ActionsAdminUser != "-" {
+		var token, err = GetImpersonationToken(ctx, flags)
+		if err != nil {
+			return errors.Wrap(err, "error obtaining the impersonation token")
+		}
+
+		// Override the initial token with the one that we got in the exchange
+		flags.Token = token
+	}
+
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: flags.Token})
 	tc := oauth2.NewClient(ctx, ts)
 	ghClient, err := github.NewEnterpriseClient(flags.BaseURL, flags.BaseURL, tc)

--- a/src/push.go
+++ b/src/push.go
@@ -39,7 +39,7 @@ func (f *PushFlags) Init(cmd *cobra.Command) {
 
 func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.BaseURL, "destination-url", "", "URL of GHES instance")
-	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "actions-admin", "The name of the Actions admin user. Pass '-' to disable the impersonation")
+	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "actions-admin", "The name of the Actions admin user (pass '-' to disable the impersonation)")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
 }

--- a/test/github.go
+++ b/test/github.go
@@ -26,6 +26,10 @@ func main() {
 	r := mux.NewRouter()
 	r.HandleFunc("/ping", func(w http.ResponseWriter, r *http.Request) {})
 
+	r.HandleFunc("/api/v3", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-github-enterprise-version", "GitHub AE")
+	})
+
 	r.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
 		currentUser := github.User{Login: &authenticatedLogin}
 		b, _ := json.Marshal(currentUser)
@@ -34,6 +38,17 @@ func main() {
 			panic(err)
 		}
 	})
+
+	r.HandleFunc("/api/v3/admin/users/actions-admin/authorizations", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-github-enterprise-version", "GitHub AE")
+		token := "token"
+		auth := github.Authorization{Token: &token}
+		b, _ := json.Marshal(auth)
+		_, err := w.Write(b)
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("POST")
 
 	r.HandleFunc("/api/v3/admin/organizations", func(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)


### PR DESCRIPTION
**Disclaimer**
_This the first PR in GO for me. I don't know how things are usually done._

## Background

The `actions-sync` app seems to also be used for the GHAE instances sometimes. The issue there was that the default admin user doesn't have permission to the actions and the github orgs. The previous workaround was to temporarily add the admin user to the required orgs and then run the app, which is not really convenient for customers who don't have access to the instance console and therefore can't run `ghe-org-admin-promote`.

We already have an app which impersonates the `actions-admin` user, and this is how it was implemented: https://github.com/github/codeql-action-sync-tool/pull/48
This PR does something similar.

## Proposed changes

* Add a new flag: `--actions-admin-user` which would accept the actions user. By default the flag is **not** set.  To use the default value, a user has to pass `actions-admin` to it. The logic is based on [this](https://github.com/github/codeql-action-sync-tool/blob/33463970b845ac4bb9e4cae6adc2a8b7cd6f6142/internal/push/push.go#L106-L113). This flag is used to impersonate the actions admin user before attempting to push the repository. Note that this logic requires the `site_admin` scope to be available in the token.
* Fixed the tests to run with the new logic which impersonates the user before the push call: I just stubbed the endpoints.
* Added the new flags to the readme.md: 👉 [rendered](https://github.com/derwasp/actions-sync/blob/derwasp/add-actions-admin-user-switch/README.md)

## Unrelated changes

* Added the artifact binary to the `.gitignore` file

## Notes

To manually test this, do the following:

1. Create a new GHAE instance (you can use a chat op).
1. Create a new personal access token for the `ghae-admin` user.
1. Spin up a new codespaces instance in this repository and checkout this PR.
1. In your codespaces build the project: `go build`.
1. Run the `actions-sync` command in your codespaces like so, where `destination-token` is the token for the `ghae-admin` user:
```
      mkdir /tmp/cache
      actions-sync sync \
        --cache-dir "/tmp/cache" \
        --destination-token "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
        --destination-url "https://ghaebuildXXXXXXXXXXXX.XXXXXX.net/" \
        --repo-name actions/setup-node \
        --actions-admin-user actions-admin
```
1. The output should look something like this:
```
    @derwasp ➜ /workspaces/actions-sync $ go build
    @derwasp ➜ /workspaces/actions-sync $ actions-sync sync \
    >     --cache-dir "/tmp/cache" \
    >     --destination-token "ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
    >     --destination-url "https://ghaebuildXXXXXXXXXXXX.XXXXXXXX.net/" \
    >     --repo-name actions/setup-node
    fetching * refs for actions/setup-node ...
    Getting an impersonation token for `actions-admin`..
    Running against GitHub AE, changing the repository scope to 'repo'..
    Got the impersonation token for `actions-admin`..
    syncing `actions/setup-node`
    successfully synced `actions/setup-node`
```
Previously the output would look something like this:
```
    fetching * refs for actions/setup-node ...
    syncing `actions/setup-node`
    error creating github repository `actions/setup-node`: error creating repository actions/setup-node: POST https://ghaebuildXXXXXXXXXXXX.XXXXXXXX.net/api/v3/orgs/actions/repos: 403 You need admin access to the organization before adding a repository to it. []
```


