### PR TITLE
Fix the impersonation token error when site_admin scope is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ When there are machines which have access to both the public internet and the GH
 
 **Arguments:**
 
-- `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `cache-dir` _(required)_
    The directory in which to cache repositories as they are synced. This speeds up re-syncing.
 - `destination-url` _(required)_
@@ -38,6 +36,8 @@ When there are machines which have access to both the public internet and the GH
    A comma-separated list of repositories to be synced. Each entry follows the format of `repo-name`.
 - `repo-name-list-file` _(optional)_
    A path to a file containing a newline separated list of repositories to be synced. Each entry follows the format of `repo-name`.
+- `actions-admin-user` _(optional)_
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 
 **Example Usage:**
 
@@ -86,8 +86,6 @@ When no machine has access to both the public internet and the GHES instance:
 
 **Arguments:**
 
-- `actions-admin-user` _(optional)_
-   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `cache-dir` _(required)_
    The directory containing the repositories fetched using the `pull` command.
 - `destination-url` _(required)_
@@ -96,6 +94,8 @@ When no machine has access to both the public internet and the GHES instance:
    A personal access token to authenticate against the GHES instance when uploading repositories. See [Destination token scopes](#destination-token-scopes) below.
 - `repo-name`, `repo-name-list` or `repo-name-list-file` _(optional)_
    Limit push to specific repositories in the cache directory.
+- `actions-admin-user` _(optional)_
+   The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 
 **Example Usage:**
 

--- a/src/push.go
+++ b/src/push.go
@@ -82,7 +82,7 @@ func GetImpersonationToken(ctx context.Context, flags *PushFlags) (string, error
 	fmt.Printf("these are the scopes we have for the current token `%s` ...\n", scopesHeader)
 
 	if !strings.Contains(scopesHeader, "site_admin") {
-		return "", errors.Wrap(err, "the current token doesn't have the `site_admin` scope, the impersonation function requires the `site_admin` permission to be able to impersonate.")
+		return "", errors.New("the current token doesn't have the `site_admin` scope, the impersonation function requires the `site_admin` permission to be able to impersonate.")
 	}
 
 	isAE := rootResponse.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue

--- a/src/push.go
+++ b/src/push.go
@@ -82,7 +82,7 @@ func GetImpersonationToken(ctx context.Context, flags *PushFlags) (string, error
 	fmt.Printf("these are the scopes we have for the current token `%s` ...\n", scopesHeader)
 
 	if !strings.Contains(scopesHeader, "site_admin") {
-		return "", errors.New("the current token doesn't have the `site_admin` scope, the impersonation function requires the `site_admin` permission to be able to impersonate.")
+		return "", errors.New("the current token doesn't have the `site_admin` scope, the impersonation function requires the `site_admin` permission to be able to impersonate")
 	}
 
 	isAE := rootResponse.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue


### PR DESCRIPTION
A recent PR: https://github.com/actions/actions-sync/pull/46 added the support of impersonation.
For this, we need `site_admin` permissions needed.

When checking the site_admin scope, if missing, the error is wrapped with `err`
`return "", errors.Wrap(err, "the current token does..)` 
But this doesn't work if err is nil.

we have to throw a new error in this case.

Before fix:

```code
getting an impersonation token for `actions-admin` ...
these are the scopes we have for the current token `admin:org, repo` ...
syncing `actions/setup-node`
error creating github repository `actions/setup-node`: error retrieving authenticated user: GET https://h2floh-080c6ccdb7ad8f2c4.ghe-test.com/api/v3/user: 401 Bad credentials []
```

After fix:

```
getting an impersonation token for `actions-admin` ...
these are the scopes we have for the current token `admin:org, repo` ...
error obtaining the impersonation token: the current token doesn't have the `site_admin` scope, the impersonation function requires the `site_admin` permission to be able to impersonate.
```


Also in Readme.md, moved optional argument (--actions-admin-user) after required fields section.

