### PR TITLE
Pass visibility flag on repository creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ When no machine has access to both the public internet and the GHES instance:
    Limit push to specific repositories in the cache directory.
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
+- `destination-is-ghae` _(optional)_
+   Indicates if the destination applicance is GHAE.
 
 **Example Usage:**
 

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ When no machine has access to both the public internet and the GHES instance:
    Limit push to specific repositories in the cache directory.
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
-- `destination-is-ghae` _(optional)_
-   Indicates if the destination applicance is GHAE.
 
 **Example Usage:**
 

--- a/script/test-build
+++ b/script/test-build
@@ -123,6 +123,16 @@ function test_push() {
   push "pushing to authenticated user's account"
   assert_dest_sha "monalisa/new-repo" "heads/main" "e9009d51dd6da2c363d1d14779c53dd27fcb0c52" "updating monalisa/new-repo"
 
+  # Push to GHAE with impersonation
+  setup_cache "org-already-exists/ghae-repo:heads/main:e9009d51dd6da2c363d1d14779c53dd27fcb0c52"
+  setup_dest "org-already-exists/ghae-repo:heads/main:a5984bb887dd2fcdc2892cd906d6f004844d1142"
+  push_impersonation "ghae-admin" "pushing to GHAE repo"
+
+  # Push to GHES with impersonation
+  setup_cache "org-already-exists/ghes-repo:heads/main:e9009d51dd6da2c363d1d14779c53dd27fcb0c52"
+  setup_dest "org-already-exists/ghes-repo:heads/main:a5984bb887dd2fcdc2892cd906d6f004844d1142"
+  push_impersonation "ghes-admin" "pushing to GHES repo"
+
   echo "all push tests passed successfully"
 }
 
@@ -311,6 +321,17 @@ function push2args() {
     "$1" "$2" \
     &> $OUTPUT ||
     fail $3
+}
+
+function push_impersonation() {
+  bin/actions-sync push \
+    --cache-dir "test/tmp/cache" \
+    --disable-push-git-auth \
+    --destination-token "token" \
+    --destination-url "http://localhost:$DEST_API_PORT" \
+    --actions-admin-user $1 \
+    &> $OUTPUT ||
+    fail "$2"
 }
 
 function sync() {

--- a/src/push.go
+++ b/src/push.go
@@ -230,6 +230,8 @@ func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName,
 		} else {
 			return nil, errors.Wrapf(err, "error creating repository %s/%s", ownerName, repoName)
 		}
+	} else if err != nil {
+		return nil, errors.Wrapf(err, "error creating repository %s/%s", ownerName, repoName)
 	}
 
 	if ghRepo == nil {

--- a/src/push.go
+++ b/src/push.go
@@ -43,7 +43,7 @@ func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "", "A user to impersonate for the push requests. To use the default name, pass 'actions-admin'. Note that the site_admin scope in the token is required for the impersonation to work.")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
-	f.IsAE = false
+	cmd.Flags().BoolVar(&f.IsAE, "destination-is-ghae", false, "Destination instance is GHAE")
 }
 
 func (f *PushFlags) Validate() Validations {

--- a/test/github.go
+++ b/test/github.go
@@ -21,6 +21,7 @@ const existingRepo string = "repo-already-exists"
 const ghaeRepo string = "ghae-repo"
 const xOAuthScopesHeader = "X-OAuth-Scopes"
 
+//nolint:gocyclo
 func main() {
 	var port, gitDaemonURL string
 	flag.StringVar(&port, "p", "", "")

--- a/test/github.go
+++ b/test/github.go
@@ -8,14 +8,18 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path"
+	"strings"
 
 	"github.com/google/go-github/v43/github"
 	"github.com/gorilla/mux"
 )
 
 var authenticatedLogin string = "monalisa"
-var existingOrg string = "org-already-exists"
-var existingRepo string = "repo-already-exists"
+
+const existingOrg string = "org-already-exists"
+const existingRepo string = "repo-already-exists"
+const ghaeRepo string = "ghae-repo"
+const xOAuthScopesHeader = "X-OAuth-Scopes"
 
 func main() {
 	var port, gitDaemonURL string
@@ -28,9 +32,14 @@ func main() {
 
 	r.HandleFunc("/api/v3", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("x-github-enterprise-version", "GitHub AE")
+		w.Header().Set(xOAuthScopesHeader, "site_admin")
 	})
 
 	r.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		if strings.Contains(token, "ghaetoken") {
+			w.Header().Set("x-github-enterprise-version", "GitHub AE")
+		}
 		currentUser := github.User{Login: &authenticatedLogin}
 		b, _ := json.Marshal(currentUser)
 		_, err := w.Write(b)
@@ -39,9 +48,19 @@ func main() {
 		}
 	})
 
-	r.HandleFunc("/api/v3/admin/users/actions-admin/authorizations", func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("x-github-enterprise-version", "GitHub AE")
+	r.HandleFunc("/api/v3/admin/users/ghes-admin/authorizations", func(w http.ResponseWriter, r *http.Request) {
 		token := "token"
+		auth := github.Authorization{Token: &token}
+		b, _ := json.Marshal(auth)
+		_, err := w.Write(b)
+		if err != nil {
+			panic(err)
+		}
+	}).Methods("POST")
+
+	r.HandleFunc("/api/v3/admin/users/ghae-admin/authorizations", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-github-enterprise-version", "GitHub AE")
+		token := "ghaetoken"
 		auth := github.Authorization{Token: &token}
 		b, _ := json.Marshal(auth)
 		_, err := w.Write(b)
@@ -114,16 +133,35 @@ func main() {
 			panic(err)
 		}
 		var repoReq struct {
-			Name string `json:"name,omitempty"`
+			Name       string `json:"name,omitempty"`
+			Visibility string `json:"visibility,omitempty"`
 		}
 		err = json.Unmarshal(b, &repoReq)
 		if err != nil {
 			panic(err)
 		}
 
-		if repoReq.Name == "repo-already-exists" {
+		var errString string = ""
+		// check visibility requirements
+		if repoReq.Name == ghaeRepo {
+			if repoReq.Visibility != "internal" {
+				errString = fmt.Sprintf("Provided repo visibility %s for GHAE must be internal", repoReq.Visibility)
+			}
+		} else {
+			if repoReq.Visibility != "public" {
+				errString = fmt.Sprintf("Provided repo visibility %s for GHES must be public", repoReq.Visibility)
+			}
+		}
+
+		// check if we are testing existing Repo
+		if repoReq.Name == existingRepo {
+			errString = fmt.Sprintf("Repo %s already exists", html.EscapeString(repoReq.Name))
+		}
+
+		// if there is an error throw it back
+		if errString != "" {
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			_, err := w.Write([]byte(fmt.Sprintf("Repo %s already exists", html.EscapeString(repoReq.Name))))
+			_, err := w.Write([]byte(errString))
 			if err != nil {
 				panic(err)
 			}


### PR DESCRIPTION
**What are you trying to achieve?**

GHAE does not have `public` repositories. So it requires that repositories which contain a consumable `Action` for GitHub Actions are created with visibility `internal`.

This PR will introduce to pass the visibility option to the repository creation step. The visibility will be `internal` for GHAE and `public` for GHES.