### PR TITLE
Add sanity test semi-automation workflow

### DIFF
--- a/.github/workflows/actions-sync-e2e-test-called.yml
+++ b/.github/workflows/actions-sync-e2e-test-called.yml
@@ -1,0 +1,34 @@
+name: Actions Sync E2E Sanity Test Reusable
+
+on:
+  workflow_call:
+    inputs:
+      runson:
+        type: string
+        required: true
+    secrets:
+      ghes_url:
+        required: true
+      actions_sync_releasedatetime:
+        required: true
+      site_admin_token:
+        required: true
+
+jobs:
+  execute:
+    runs-on: ${{ inputs.runson }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: Bootstrap
+      run: |
+        .\script\bootstrap-sanity-test.ps1
+      shell: pwsh
+      env:
+        RELEASEDATE: ${{ secrets.actions_sync_releasedatetime }}
+    - name: Test execution
+      run: |
+        .\script\execute-sanity-test.ps1
+      shell: pwsh
+      env:
+        TOKEN: ${{ secrets.site_admin_token }}
+        TEST_INSTANCE_URL: ${{ secrets.ghes_url }}

--- a/.github/workflows/actions-sync-e2e-test-caller.yml
+++ b/.github/workflows/actions-sync-e2e-test-caller.yml
@@ -1,0 +1,19 @@
+name: Actions Sync E2E Sanity Test
+
+on:
+  workflow_dispatch:
+
+jobs:
+  sanity-test:
+    strategy:
+      fail-fast: false
+      matrix:
+        runson: [ubuntu-latest, macos-latest, windows-latest]
+    uses: ./.github/workflows/actions-sync-e2e-test-called.yml
+    with:
+      runson: ${{ matrix.runson }}
+    secrets:
+      ghes_url: ${{ secrets.sanity_test_ghes_url }}
+      actions_sync_releasedatetime: ${{ secrets.sanity_test_releasedatetime }}
+      site_admin_token: ${{ secrets.sanity_test_site_admin_token }}
+

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,40 @@
+# Release process
+
+When we want to do a new release, push a git tag with format `v**` and workflow `releases.yml` executes.
+
+This workflow internally uses [go-releaser](https://goreleaser.com/ci/actions/) to push a new release.
+
+Please follow the below detailed steps.
+- Create a tag in format `v202205240715`
+```code
+git tag -a `date "+v%Y%m%d%H%M"` -m "Release a new version"
+```
+- Get the tag name
+```code
+git tag
+```
+- Push the newly created tag
+```code
+git push origin <tag>
+```
+- Check workflow `releases.yml` should trigger
+- Once completed, go to repo releases page and edit the newly created release as `pre-release`, so we can do sanity testig before we officicaly release
+- Recommend to do basic sanity testing (see below) on the new release.
+- Once sanity testing is done, we can edit the releas and mark it as `Latest version` and edit the release notes.
+
+## Basic Sanity testing
+
+### Prerequisite
+
+1. Access to a GHES test server
+1. Create a PAT token with `site-admin` scope in the GHES environment for `ghe-admin`
+
+### Execution
+
+1. Update below Repository level secrets:
+
+    - sanity_test_site_admin_token: The PAT generated earlier 
+    - sanity_test_ghes_url: The URL to the GHES instance 
+    - sanity_test_releasedatetime: The datetime string for the release to test without the `v` (e.g. `202211070205`)
+
+1. Manually trigger this workflow: https://github.com/actions/actions-sync/actions/workflows/actions-sync-e2e-test-caller.yml

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -17,10 +17,10 @@ git tag
 ```code
 git push origin <tag>
 ```
-- Check workflow `releases.yml` should trigger
-- Once completed, go to repo releases page and edit the newly created release as `pre-release`, so we can do sanity testig before we officicaly release
+- Check that workflow [`releases.yml`](https://github.com/actions/actions-sync/actions/workflows/releases.yml) was triggered
+- Once completed, [go to repo releases page](https://github.com/actions/actions-sync/releases) and edit the newly created release as `pre-release`, so we can do sanity testing before we officially release
 - Recommend to do basic sanity testing (see below) on the new release.
-- Once sanity testing is done, we can edit the releas and mark it as `Latest version` and edit the release notes.
+- Once sanity testing is done, we can edit the release and mark it as `Latest version` and edit the release notes.
 
 ## Basic Sanity testing
 
@@ -35,6 +35,6 @@ git push origin <tag>
 
     - sanity_test_site_admin_token: The PAT generated earlier 
     - sanity_test_ghes_url: The URL to the GHES instance 
-    - sanity_test_releasedatetime: The datetime string for the release to test without the `v` (e.g. `202211070205`)
+    - sanity_test_releasedatetime: The tag datetime string for the release to test without the `v` (e.g. `202211070205`)
 
 1. Manually trigger this workflow: https://github.com/actions/actions-sync/actions/workflows/actions-sync-e2e-test-caller.yml

--- a/script/bootstrap-sanity-test.ps1
+++ b/script/bootstrap-sanity-test.ps1
@@ -1,0 +1,17 @@
+# Determine file to download based on current OS
+if($IsLinux) {
+   $file_postfix = "linux_amd64"
+} elseif ($IsWindows) {
+   $file_postfix = "windows_amd64"
+} elseif ($IsMacOS) {
+    $file_postfix = "darwin_amd64"
+}
+
+# Download release to test
+curl -OL "https://github.com/actions/actions-sync/releases/download/v$Env:RELEASEDATE/gh_$Env:RELEASEDATE`_$file_postfix.tar.gz"
+
+# extract
+tar -xvzf "gh_$Env:RELEASEDATE`_$file_postfix.tar.gz"
+
+# prepare cache directory
+mkdir -p cache

--- a/script/execute-sanity-test.ps1
+++ b/script/execute-sanity-test.ps1
@@ -1,0 +1,23 @@
+# Testing Pull Single Repo
+echo "`n#########################`n### Testing Pull Single Repo`n#########################"
+bin/actions-sync pull --cache-dir "cache"  --repo-name "actions/setup-node"
+
+# Testing Sync Single Repo
+echo "`n#########################`n### Testing Sync Single Repo`n#########################"
+bin/actions-sync sync --cache-dir "cache" --destination-token $Env:TOKEN --destination-url $Env:TEST_INSTANCE_URL --repo-name "actions/setup-node" --actions-admin-user actions-admin
+
+# Testing Pull Multiple Repos
+echo "`n#########################`n### Testing Pull Multiple Repos`n#########################"
+bin/actions-sync pull --cache-dir "cache"  --repo-name-list "actions/setup-node,actions/checkout"
+
+# Testing Push Multiple Existing Repos
+echo "`n#########################`n### Testing Push Multiple Existing Repos`n#########################"
+bin/actions-sync push --cache-dir "cache" --destination-token $Env:TOKEN --destination-url $Env:TEST_INSTANCE_URL --repo-name-list "actions/setup-node,actions/checkout" --actions-admin-user actions-admin
+
+# Testing Sync Multiple Existing Repos
+echo "`n#########################`n### Testing Sync Multiple Existing Repos`n#########################"
+bin/actions-sync sync --cache-dir "cache" --destination-token $Env:TOKEN --destination-url $Env:TEST_INSTANCE_URL --repo-name-list "actions/setup-node,actions/checkout" --actions-admin-user actions-admin
+
+# Testing Sync New Single Repo
+echo "`n#########################`n### Testing Sync New Single Repo`n#########################"
+bin/actions-sync sync --cache-dir "cache" --destination-token $Env:TOKEN --destination-url $Env:TEST_INSTANCE_URL --repo-name-list "actions/actions-sync" --actions-admin-user actions-admin


### PR DESCRIPTION
Adding workflow and scripts to do a partial automation of the sanity-test.

We still need to create the GHES instance and a site_admin PAT token.

Workflow will download and run the sanity check the 64bit binaries for linux, windows and macos.

Added documentation on how to do a release and execute the sanity test for the new release.