### PR TITLE
Changes to release workflow and architecture options

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -13,14 +13,14 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up Go 1.14
-        uses: actions/setup-go@v3
+      - name: Set up Go
+        uses: actions/setup-go@v4
       - name: Set CURRENT_TAG
         run: echo "GORELEASER_CURRENT_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,12 +5,12 @@ builds:
       binary: bin/actions-sync
     id: macos
     goos: [darwin]
-    goarch: [amd64]
+    goarch: [amd64, arm64]
   - <<: *build_defaults
     id: linux
     goos: [linux]
-    goarch: [386, amd64, arm64]
+    goarch: [amd64, arm64]
   - <<: *build_defaults
     id: windows
     goos: [windows]
-    goarch: [386, amd64]
+    goarch: [amd64]


### PR DESCRIPTION
- Generally remove 386 arch
- Add macos arm64
- Switch from deprecated `--rm-dist` to `--clean` flag for goreleaser
- Bump `actions/setup-go` to v4 