### PR TITLE
Explicitly set CGO_ENABLED=0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,16 +1,26 @@
-project_name: gh
+project_name: actions/actions-sync
 
 builds:
-  - <<: &build_defaults
-      binary: bin/actions-sync
-    id: macos
-    goos: [darwin]
-    goarch: [amd64, arm64]
-  - <<: *build_defaults
-    id: linux
-    goos: [linux]
-    goarch: [amd64, arm64]
-  - <<: *build_defaults
-    id: windows
-    goos: [windows]
-    goarch: [amd64]
+  - id: build
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    binary: bin/actions-sync
+    ignore:
+      - goos: windows
+        goarch: arm64
+    env:
+      - CGO_ENABLED=0
+release:
+  github:
+    owner: actions
+    name: actions-sync
+  # Create the release as a draft so it can be tested before being published
+  # To test, go to the Actions tab and run the "Actions Sync E2E Sanity Test" workflow
+  draft: true
+
+

--- a/script/build
+++ b/script/build
@@ -7,4 +7,4 @@ test -z "${DEBUG:-}" || {
     set -x
 }
 
-CG0_ENABLED=0 go build -o bin/actions-sync main.go
+CGO_ENABLED=0 go build -o bin/actions-sync main.go

--- a/script/build
+++ b/script/build
@@ -7,4 +7,4 @@ test -z "${DEBUG:-}" || {
     set -x
 }
 
-go build -o bin/actions-sync main.go
+CG0_ENABLED=0 go build -o bin/actions-sync main.go


### PR DESCRIPTION
Relates to #95 

Updating `script/build` and `.goreleaser` to explicitly set `CGO_ENABLED=0`. This is required after upgrading to Go >= `1.20`. 

Even though we're not using CGO directly, some packages in the standard library like `net` (that we do use) will implicitly use the CGO implementation if the build environment has the C tools available. Starting in Go `1.20` the standard library does not ship pre-compiled archives, so to suppress this behavior CGO must be explicitly disabled.

See https://github.com/golang/go/issues/58550 for more details


In addition I also made minor changes to the `.goreleaser.yml` config to make it easier to read as well as to force the use of `draft` releases which is implicitly called out in the [release docs](https://github.com/actions/actions-sync/blob/main/docs/RELEASE.md)
