### PR TITLE
chore: update CODEOWNERS with active teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-* @actions/actions-delivery-nexus @actions/actions-oss-maintainers
+* @actions/actions-oss-maintainers @actions/actions-sync-maintainers
 


### PR DESCRIPTION
## Summary

Replace the empty `@actions/actions-delivery-nexus` team with the newly created `@actions/actions-sync-maintainers` team.

## Changes

- Remove `@actions/actions-delivery-nexus` (empty/orphaned team)
- Add `@actions/actions-sync-maintainers`
- Keep `@actions/actions-oss-maintainers` (active team)

## Context

The `actions-delivery-nexus` team has 0 members and is not managed via entitlements, which has been blocking PR reviews.