### PR TITLE
feat: add GitHub App installation token authentication for push/sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ When there are machines which have access to both the public internet and the GH
    A path to a file containing a newline separated list of repositories to be synced. Each entry follows the format of `repo-name`.
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
+- `github-app-auth` _(optional)_
+   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name. See [GitHub App authentication](#github-app-authentication) below.
 - `batch-size` _(optional)_
    Number of refs to push in each batch. Default is 0 (no batching). Use a value like 100 if pushing fails for large repositories with many branches and tags.
 
@@ -116,6 +118,8 @@ When no machine has access to both the public internet and the GHES instance:
    Limit push to specific repositories in the cache directory.
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
+- `github-app-auth` _(optional)_
+   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name. See [GitHub App authentication](#github-app-authentication) below.
 - `batch-size` _(optional)_
    Number of refs to push in each batch. Default is 0 (no batching). Use a value like 100 if pushing fails for large repositories with many branches and tags.
 
@@ -132,3 +136,24 @@ When no machine has access to both the public internet and the GHES instance:
 
 When creating a personal access token include the `repo` and `workflow` scopes. Include the `site_admin` scope (optional) if you want organizations to be created as necessary or you want to use the impersonation logic for the `push` or `sync` commands.
 
+## GitHub App authentication
+
+Instead of a personal access token you can authenticate `push`/`sync` using a GitHub App installation token (`ghs_*`). This avoids long-lived PATs and aligns with enterprise security practices.
+
+1. Create a GitHub App on the destination GHES instance and install it on the target organization(s).
+2. Grant the App these repository permissions: `Administration: Read & write` (to create repositories), `Contents: Read & write` and `Metadata: Read & only`. Add `Workflows: Read & write` if the synced repositories contain workflow files.
+3. Generate an installation access token (`ghs_*`) for the installation.
+4. Pass the token as `--destination-token` together with the `--github-app-auth` flag:
+
+```
+  actions-sync push \
+    --cache-dir "/tmp/cache" \
+    --destination-token "ghs_xxxxxxxxxxxxxxxxxxxx" \
+    --destination-url "https://www.example.com" \
+    --github-app-auth
+```
+
+Notes:
+
+- App installation tokens have no user context, so `--github-app-auth` skips the `GET /user` call and creates repositories under the owner taken from the destination repo name (`owner/repo`). The installation must have access to that owner.
+- Organization auto-creation and user-impersonation (`--actions-admin-user`) rely on user/site-admin context and are not used with App auth.

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ When creating a personal access token include the `repo` and `workflow` scopes. 
 Instead of a personal access token you can authenticate `push`/`sync` using a GitHub App installation token (`ghs_*`). This avoids long-lived PATs and aligns with enterprise security practices.
 
 1. Create a GitHub App on the destination GHES instance and install it on the target organization(s). The destination owner must be an organization: installation tokens cannot create user-owned repositories (`POST /user/repos` requires user context that App tokens lack), so a user-account installation will not work.
-2. Grant the App these repository permissions: `Administration: Read & write` (to create repositories), `Contents: Read & write` and `Metadata: Read & only`. Add `Workflows: Read & write` if the synced repositories contain workflow files.
+2. Grant the App these repository permissions: `Administration: Read & write` (to create repositories), `Contents: Read & write` and `Metadata: Read-only`. Add `Workflows: Read & write` if the synced repositories contain workflow files.
 3. Generate an installation access token (`ghs_*`) for the installation.
 4. Pass the token as `--destination-token` together with the `--github-app-auth` flag:
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ When there are machines which have access to both the public internet and the GH
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `github-app-auth` _(optional)_
-   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name. See [GitHub App authentication](#github-app-authentication) below.
+   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name, which must be an organization the App is installed on (installation tokens cannot create user-owned repositories). See [GitHub App authentication](#github-app-authentication) below.
 - `batch-size` _(optional)_
    Number of refs to push in each batch. Default is 0 (no batching). Use a value like 100 if pushing fails for large repositories with many branches and tags.
 
@@ -119,7 +119,7 @@ When no machine has access to both the public internet and the GHES instance:
 - `actions-admin-user` _(optional)_
    The name of the Actions admin user, which will be used for updating the chosen action. To use the default user, pass `actions-admin`. If not set, the impersonation is disabled. Note that `site_admin` scope is required in the token for the impersonation to work.
 - `github-app-auth` _(optional)_
-   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name. See [GitHub App authentication](#github-app-authentication) below.
+   Authenticate using a GitHub App installation token (`ghs_*`) instead of a personal access token. App tokens have no user context, so the user API call is skipped and repositories are created under the owner taken from the destination repo name, which must be an organization the App is installed on (installation tokens cannot create user-owned repositories). See [GitHub App authentication](#github-app-authentication) below.
 - `batch-size` _(optional)_
    Number of refs to push in each batch. Default is 0 (no batching). Use a value like 100 if pushing fails for large repositories with many branches and tags.
 
@@ -140,7 +140,7 @@ When creating a personal access token include the `repo` and `workflow` scopes. 
 
 Instead of a personal access token you can authenticate `push`/`sync` using a GitHub App installation token (`ghs_*`). This avoids long-lived PATs and aligns with enterprise security practices.
 
-1. Create a GitHub App on the destination GHES instance and install it on the target organization(s).
+1. Create a GitHub App on the destination GHES instance and install it on the target organization(s). The destination owner must be an organization: installation tokens cannot create user-owned repositories (`POST /user/repos` requires user context that App tokens lack), so a user-account installation will not work.
 2. Grant the App these repository permissions: `Administration: Read & write` (to create repositories), `Contents: Read & write` and `Metadata: Read & only`. Add `Workflows: Read & write` if the synced repositories contain workflow files.
 3. Generate an installation access token (`ghs_*`) for the installation.
 4. Pass the token as `--destination-token` together with the `--github-app-auth` flag:
@@ -155,5 +155,5 @@ Instead of a personal access token you can authenticate `push`/`sync` using a Gi
 
 Notes:
 
-- App installation tokens have no user context, so `--github-app-auth` skips the `GET /user` call and creates repositories under the owner taken from the destination repo name (`owner/repo`). The installation must have access to that owner.
+- App installation tokens have no user context, so `--github-app-auth` skips the `GET /user` call and creates repositories under the owner taken from the destination repo name (`owner/repo`) via `POST /orgs/{owner}/repos`. The owner must therefore be an organization the App is installed on; user-owned destinations are not supported because installation tokens cannot create user-owned repositories.
 - Organization auto-creation and user-impersonation (`--actions-admin-user`) rely on user/site-admin context and are not used with App auth.

--- a/script/test-build
+++ b/script/test-build
@@ -133,6 +133,12 @@ function test_push() {
   setup_dest "org-already-exists/ghes-repo:heads/main:a5984bb887dd2fcdc2892cd906d6f004844d1142"
   push_impersonation "ghes-admin" "pushing to GHES repo"
 
+  # Push with GitHub App auth (ghs_* token, user API unavailable)
+  setup_cache "org-already-exists/app-repo:heads/main:e9009d51dd6da2c363d1d14779c53dd27fcb0c52"
+  setup_dest "org-already-exists/app-repo:heads/main:a5984bb887dd2fcdc2892cd906d6f004844d1142"
+  push_github_app "pushing with GitHub App auth"
+  assert_dest_sha "org-already-exists/app-repo" "heads/main" "e9009d51dd6da2c363d1d14779c53dd27fcb0c52" "updating org-already-exists/app-repo with GitHub App auth"
+
   echo "all push tests passed successfully"
 }
 
@@ -344,6 +350,17 @@ function push_impersonation() {
     --actions-admin-user $1 \
     &>$OUTPUT ||
     fail "$2"
+}
+
+function push_github_app() {
+  bin/actions-sync push \
+    --cache-dir "test/tmp/cache" \
+    --disable-push-git-auth \
+    --destination-token "ghs_installationtoken" \
+    --destination-url "http://localhost:$DEST_API_PORT" \
+    --github-app-auth \
+    &>$OUTPUT ||
+    fail "$1"
 }
 
 function sync() {

--- a/src/push.go
+++ b/src/push.go
@@ -315,7 +315,7 @@ func syncWithCachedRepository(ctx context.Context, flags *PushFlags, ghRepo *git
 	var auth transport.AuthMethod
 	if !flags.DisableGitAuth {
 		auth = &http.BasicAuth{
-			Username: "username",
+			Username: "x-access-token",
 			Password: flags.Token,
 		}
 	}

--- a/src/push.go
+++ b/src/push.go
@@ -69,6 +69,9 @@ func (f *PushOnlyFlags) Validate() Validations {
 	if f.BatchSize != 0 && f.BatchSize < MinBatchSize {
 		validations = append(validations, fmt.Sprintf("--batch-size must be 0 (no batching) or at least %d", MinBatchSize))
 	}
+	if f.GitHubApp && f.ActionsAdminUser != "" {
+		validations = append(validations, "--github-app-auth cannot be used with --actions-admin-user; App installation tokens have no user/site-admin context and cannot impersonate")
+	}
 	return validations
 }
 

--- a/src/push.go
+++ b/src/push.go
@@ -31,7 +31,7 @@ const MinBatchSize = 10
 
 type PushOnlyFlags struct {
 	BaseURL, Token, ActionsAdminUser string
-	DisableGitAuth                   bool
+	DisableGitAuth, GitHubApp        bool
 	BatchSize                        int
 }
 
@@ -50,6 +50,7 @@ func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "", "A user to impersonate for the push requests. To use the default name, pass 'actions-admin'. Note that the site_admin scope in the token is required for the impersonation to work.")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
+	cmd.Flags().BoolVar(&f.GitHubApp, "github-app-auth", false, "Authenticate using a GitHub App installation token (ghs_*). Skips the user API call, which App tokens cannot use; repositories are created under the owner from the destination repo name.")
 	cmd.Flags().IntVar(&f.BatchSize, "batch-size", DefaultBatchSize, "Number of refs to push in each batch (0 = no batching). Use a value like 100 if pushing fails for large repositories.")
 }
 
@@ -178,7 +179,7 @@ func PushWithGitImpl(ctx context.Context, flags *PushFlags, repoName string, ghC
 	}
 
 	fmt.Printf("syncing `%s`\n", nwo)
-	ghRepo, err := getOrCreateGitHubRepo(ctx, ghClient, bareRepoName, ownerName)
+	ghRepo, err := getOrCreateGitHubRepo(ctx, ghClient, bareRepoName, ownerName, flags.GitHubApp)
 	if err != nil {
 		return errors.Wrapf(err, "error creating github repository `%s`", nwo)
 	}
@@ -190,30 +191,13 @@ func PushWithGitImpl(ctx context.Context, flags *PushFlags, repoName string, ghC
 	return nil
 }
 
-func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName, ownerName string) (*github.Repository, error) {
-	// retrieve user associated to authentication credentials provided
-	currentUser, userResponse, err := client.Users.Get(ctx, "")
+func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName, ownerName string, githubApp bool) (*github.Repository, error) {
+	// Determine the org under which to create the repo. With GitHub App auth the
+	// user API is unavailable (App tokens have no user context), so this is
+	// resolved without calling Users.Get.
+	createRepoOrgName, isAE, aeDetermined, err := resolveCreateOrgName(ctx, client, ownerName, githubApp)
 	if err != nil {
-		return nil, errors.Wrap(err, "error retrieving authenticated user")
-	}
-	if currentUser == nil || currentUser.Login == nil {
-		return nil, errors.New("error retrieving authenticated user's login name")
-	}
-	// checking if we talk to GHAE
-	isAE := userResponse.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue
-
-	// check if the owner refers to the authenticated user or an organization.
-	var createRepoOrgName string
-	if strings.EqualFold(*currentUser.Login, ownerName) {
-		// we'll create the repo under the authenticated user's account.
-		createRepoOrgName = ""
-	} else {
-		// ensure the org exists.
-		createRepoOrgName = ownerName
-		_, err := getOrCreateGitHubOrg(ctx, client, ownerName, *currentUser.Login)
-		if err != nil {
-			return nil, err
-		}
+		return nil, err
 	}
 
 	// check if repository already exists
@@ -223,6 +207,11 @@ func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName,
 		fmt.Printf("Existing repo `%s/%s`\n", ownerName, repoName)
 	} else if resp != nil && resp.StatusCode == 404 {
 		// repo not existing yet - try to create
+		// With GitHub App auth the enterprise version wasn't determined from the
+		// user response, so fall back to the repository response header.
+		if !aeDetermined {
+			isAE = resp.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue
+		}
 		visibility := github.String("public")
 		if isAE {
 			visibility = github.String("internal")
@@ -250,6 +239,42 @@ func getOrCreateGitHubRepo(ctx context.Context, client *github.Client, repoName,
 		return nil, errors.New("error repository is nil")
 	}
 	return ghRepo, nil
+}
+
+// resolveCreateOrgName decides which org the repo should be created under and,
+// for PAT auth, reports whether the destination is a GitHub AE instance (derived
+// from the authenticated user response). With GitHub App auth (ghs_* tokens) the
+// user API is unavailable, so the repo is always created under the owner from the
+// destination repo name and the AE determination is deferred to the caller
+// (aeDetermined is false).
+func resolveCreateOrgName(ctx context.Context, client *github.Client, ownerName string, githubApp bool) (createOrgName string, isAE bool, aeDetermined bool, err error) {
+	if githubApp {
+		return ownerName, false, false, nil
+	}
+
+	// retrieve user associated to authentication credentials provided
+	currentUser, userResponse, err := client.Users.Get(ctx, "")
+	if err != nil {
+		return "", false, false, errors.Wrap(err, "error retrieving authenticated user (for GitHub App auth pass --github-app-auth)")
+	}
+	if currentUser == nil || currentUser.Login == nil {
+		return "", false, false, errors.New("error retrieving authenticated user's login name")
+	}
+
+	// checking if we talk to GHAE
+	isAE = userResponse.Header.Get(enterpriseVersionHeaderKey) == enterpriseAegisVersionHeaderValue
+
+	// check if the owner refers to the authenticated user or an organization.
+	if strings.EqualFold(*currentUser.Login, ownerName) {
+		// we'll create the repo under the authenticated user's account.
+		return "", isAE, true, nil
+	}
+
+	// ensure the org exists.
+	if _, err := getOrCreateGitHubOrg(ctx, client, ownerName, *currentUser.Login); err != nil {
+		return "", isAE, true, err
+	}
+	return ownerName, isAE, true, nil
 }
 
 func getOrCreateGitHubOrg(ctx context.Context, client *github.Client, orgName, admin string) (*github.Organization, error) {

--- a/src/push.go
+++ b/src/push.go
@@ -50,7 +50,7 @@ func (f *PushOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.ActionsAdminUser, "actions-admin-user", "", "A user to impersonate for the push requests. To use the default name, pass 'actions-admin'. Note that the site_admin scope in the token is required for the impersonation to work.")
 	cmd.Flags().StringVar(&f.Token, "destination-token", "", "Token to access API on GHES instance")
 	cmd.Flags().BoolVar(&f.DisableGitAuth, "disable-push-git-auth", false, "Disables git authentication whilst pushing")
-	cmd.Flags().BoolVar(&f.GitHubApp, "github-app-auth", false, "Authenticate using a GitHub App installation token (ghs_*). Skips the user API call, which App tokens cannot use; repositories are created under the owner from the destination repo name.")
+	cmd.Flags().BoolVar(&f.GitHubApp, "github-app-auth", false, "Authenticate using a GitHub App installation token (ghs_*). Skips the user API call, which App tokens cannot use; repositories are created under the owner from the destination repo name, which must be an organization the App is installed on (installation tokens cannot create user-owned repositories).")
 	cmd.Flags().IntVar(&f.BatchSize, "batch-size", DefaultBatchSize, "Number of refs to push in each batch (0 = no batching). Use a value like 100 if pushing fails for large repositories.")
 }
 

--- a/src/push_test.go
+++ b/src/push_test.go
@@ -4,96 +4,19 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
-	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
-	"github.com/go-git/go-git/v5/plumbing/storer"
 	"github.com/google/go-github/v43/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-// Mock implementations for testing
-
-type mockReferenceIter struct {
-	refs  []*plumbing.Reference
-	index int
-}
-
-func (m *mockReferenceIter) Next() (*plumbing.Reference, error) {
-	if m.index >= len(m.refs) {
-		return nil, storer.ErrStop
-	}
-	ref := m.refs[m.index]
-	m.index++
-	return ref, nil
-}
-
-func (m *mockReferenceIter) ForEach(fn func(*plumbing.Reference) error) error {
-	for _, ref := range m.refs {
-		if err := fn(ref); err != nil {
-			if err == storer.ErrStop {
-				return nil
-			}
-			return err
-		}
-	}
-	return nil
-}
-
-func (m *mockReferenceIter) Close() {}
-
-type mockGitRepository struct {
-	refs []*plumbing.Reference
-	err  error
-}
-
-func (m *mockGitRepository) DeleteRemote(name string) error {
-	return nil
-}
-
-func (m *mockGitRepository) CreateRemote(c *config.RemoteConfig) (GitRemote, error) {
-	return nil, nil
-}
-
-func (m *mockGitRepository) FetchContext(ctx context.Context, o *git.FetchOptions) error {
-	return nil
-}
-
-func (m *mockGitRepository) References() (storer.ReferenceIter, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &mockReferenceIter{refs: m.refs, index: 0}, nil
-}
-
-type mockGitRemote struct {
-	pushCalls       [][]config.RefSpec
-	pushError       error
-	alreadyUpToDate bool
-	remoteConfig    *config.RemoteConfig
-}
-
-func (m *mockGitRemote) PushContext(ctx context.Context, o *git.PushOptions) error {
-	m.pushCalls = append(m.pushCalls, o.RefSpecs)
-	if m.alreadyUpToDate {
-		return git.NoErrAlreadyUpToDate
-	}
-	return m.pushError
-}
-
-func (m *mockGitRemote) Config() *config.RemoteConfig {
-	if m.remoteConfig != nil {
-		return m.remoteConfig
-	}
-	return &config.RemoteConfig{Name: "test-remote"}
-}
+// Mocks, fakes and helpers shared across the package's tests live in
+// testutils_test.go.
 
 // Tests for PushOnlyFlags.Validate batch size validation
 
@@ -396,24 +319,6 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, 10, MinBatchSize, "MinBatchSize should be 10")
 }
 
-// Helper function to create N test refs
-func createNRefs(n int) []plumbing.ReferenceName {
-	refs := make([]plumbing.ReferenceName, n)
-	for i := 0; i < n; i++ {
-		refs[i] = plumbing.NewBranchReferenceName(fmt.Sprintf("branch-%d", i))
-	}
-	return refs
-}
-
-// newTestGitHubClient returns a github.Client whose API requests are routed to
-// the provided test server.
-func newTestGitHubClient(t *testing.T, serverURL string) *github.Client {
-	t.Helper()
-	client, err := github.NewEnterpriseClient(serverURL, serverURL, nil)
-	require.NoError(t, err)
-	return client
-}
-
 // Tests for the --github-app-auth flag
 
 func TestPushOnlyFlags_GitHubAppAuth_Valid(t *testing.T) {
@@ -555,144 +460,6 @@ func TestResolveCreateOrgName_PAT_UserError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "", orgName)
 	assert.Contains(t, err.Error(), "--github-app-auth", "error should hint at GitHub App auth flag")
-}
-
-// fakeGitHub is a configurable mock of the GitHub REST API exercised by
-// getOrCreateGitHubRepo. It records which endpoints were hit so tests can assert
-// on the resulting behaviour (e.g. that App auth never calls /user and that
-// repositories are created under the expected owner with the expected visibility).
-type fakeGitHub struct {
-	// config
-	userLogin         string // login returned by GET /user
-	userAE            bool   // set the AE version header on the GET /user response
-	userStatus        int    // override GET /user status (0 => 200)
-	repoExists        bool   // GET /repos/{owner}/{repo} returns 200 vs 404
-	repoGetAE         bool   // set the AE version header on the GET /repos response
-	repoGetStatus     int    // override GET /repos status (0 => derived from repoExists)
-	createRepoStatus  int    // override POST repos status (0 => 201 Created)
-	orgCreateConflict bool   // POST /admin/organizations returns 422 (already exists)
-	orgGetExists      bool   // GET /orgs/{org} returns 200 (used as create fallback)
-
-	// recorded
-	userCalled       bool
-	created          bool
-	createdUnderUser bool
-	createdOrg       string
-	createdName      string
-	createdVis       string
-	createOrgCalled  bool
-	orgGetCalled     bool
-}
-
-func (f *fakeGitHub) handler(t *testing.T) http.HandlerFunc {
-	t.Helper()
-	return func(w http.ResponseWriter, r *http.Request) {
-		switch {
-		case r.URL.Path == "/api/v3/user" && r.Method == http.MethodGet:
-			f.userCalled = true
-			if f.userStatus != 0 {
-				w.WriteHeader(f.userStatus)
-				_, _ = w.Write([]byte(`{"message":"no user context"}`))
-				return
-			}
-			if f.userAE {
-				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
-			}
-			login := f.userLogin
-			b, _ := json.Marshal(github.User{Login: &login})
-			_, _ = w.Write(b)
-
-		case strings.HasPrefix(r.URL.Path, "/api/v3/repos/") && r.Method == http.MethodGet:
-			parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/v3/repos/"), "/")
-			owner, repo := parts[0], parts[1]
-			status := f.repoGetStatus
-			if status == 0 {
-				if f.repoExists {
-					status = http.StatusOK
-				} else {
-					status = http.StatusNotFound
-				}
-			}
-			if f.repoGetAE {
-				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
-			}
-			if status == http.StatusOK {
-				cloneURL := "https://example.com/" + owner + "/" + repo + ".git"
-				b, _ := json.Marshal(github.Repository{Name: github.String(repo), CloneURL: &cloneURL})
-				_, _ = w.Write(b)
-				return
-			}
-			w.WriteHeader(status)
-			_, _ = w.Write([]byte(`{"message":"not found"}`))
-
-		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && strings.HasSuffix(r.URL.Path, "/repos") && r.Method == http.MethodPost:
-			org := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/"), "/repos")
-			f.createdOrg = org
-			f.recordCreate(r, w, org)
-
-		case r.URL.Path == "/api/v3/user/repos" && r.Method == http.MethodPost:
-			f.createdUnderUser = true
-			f.recordCreate(r, w, "")
-
-		case r.URL.Path == "/api/v3/admin/organizations" && r.Method == http.MethodPost:
-			f.createOrgCalled = true
-			if f.orgCreateConflict {
-				w.WriteHeader(http.StatusUnprocessableEntity)
-				_, _ = w.Write([]byte(`{"message":"Organization already exists"}`))
-				return
-			}
-			var body struct {
-				Login string `json:"login"`
-			}
-			data, _ := io.ReadAll(r.Body)
-			_ = json.Unmarshal(data, &body)
-			b, _ := json.Marshal(github.Organization{Login: github.String(body.Login)})
-			_, _ = w.Write(b)
-
-		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && r.Method == http.MethodGet:
-			f.orgGetCalled = true
-			org := strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/")
-			if !f.orgGetExists {
-				w.WriteHeader(http.StatusNotFound)
-				_, _ = w.Write([]byte(`{"message":"not found"}`))
-				return
-			}
-			b, _ := json.Marshal(github.Organization{Login: github.String(org)})
-			_, _ = w.Write(b)
-
-		default:
-			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-	}
-}
-
-func (f *fakeGitHub) recordCreate(r *http.Request, w http.ResponseWriter, org string) {
-	f.created = true
-	var body struct {
-		Name       string `json:"name"`
-		Visibility string `json:"visibility"`
-	}
-	data, _ := io.ReadAll(r.Body)
-	_ = json.Unmarshal(data, &body)
-	f.createdName = body.Name
-	f.createdVis = body.Visibility
-	if f.createRepoStatus != 0 {
-		w.WriteHeader(f.createRepoStatus)
-		_, _ = w.Write([]byte(`{"message":"validation failed"}`))
-		return
-	}
-	cloneURL := "https://example.com/" + org + "/" + body.Name + ".git"
-	w.WriteHeader(http.StatusCreated)
-	b, _ := json.Marshal(github.Repository{Name: github.String(body.Name), CloneURL: &cloneURL})
-	_, _ = w.Write(b)
-}
-
-func (f *fakeGitHub) start(t *testing.T) *github.Client {
-	t.Helper()
-	server := httptest.NewServer(f.handler(t))
-	t.Cleanup(server.Close)
-	return newTestGitHubClient(t, server.URL)
 }
 
 // Tests for getOrCreateGitHubRepo with GitHub App auth (new behaviour)

--- a/src/push_test.go
+++ b/src/push_test.go
@@ -2,13 +2,17 @@ package src
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/google/go-github/v43/github"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,10 +72,10 @@ func (m *mockGitRepository) References() (storer.ReferenceIter, error) {
 }
 
 type mockGitRemote struct {
-	pushCalls      [][]config.RefSpec
-	pushError      error
+	pushCalls       [][]config.RefSpec
+	pushError       error
 	alreadyUpToDate bool
-	remoteConfig   *config.RemoteConfig
+	remoteConfig    *config.RemoteConfig
 }
 
 func (m *mockGitRemote) PushContext(ctx context.Context, o *git.PushOptions) error {
@@ -279,8 +283,8 @@ func TestPushRefsInBatches(t *testing.T) {
 			expectedBatches: 1,
 		},
 		{
-			name: "single batch - exact batch size",
-			refs: createNRefs(10),
+			name:            "single batch - exact batch size",
+			refs:            createNRefs(10),
 			batchSize:       10,
 			expectedBatches: 1,
 		},
@@ -397,4 +401,135 @@ func createNRefs(n int) []plumbing.ReferenceName {
 		refs[i] = plumbing.NewBranchReferenceName(fmt.Sprintf("branch-%d", i))
 	}
 	return refs
+}
+
+// newTestGitHubClient returns a github.Client whose API requests are routed to
+// the provided test server.
+func newTestGitHubClient(t *testing.T, serverURL string) *github.Client {
+	t.Helper()
+	client, err := github.NewEnterpriseClient(serverURL, serverURL, nil)
+	require.NoError(t, err)
+	return client
+}
+
+// Tests for the --github-app-auth flag
+
+func TestPushOnlyFlags_GitHubAppAuth_Valid(t *testing.T) {
+	flags := PushOnlyFlags{
+		BaseURL:   "https://example.com",
+		Token:     "ghs_token",
+		GitHubApp: true,
+	}
+
+	validations := flags.Validate()
+
+	for _, v := range validations {
+		assert.NotContains(t, v, "github-app-auth", "unexpected github-app-auth validation error")
+	}
+}
+
+// Tests for resolveCreateOrgName
+
+func TestResolveCreateOrgName_GitHubApp(t *testing.T) {
+	// With App auth the user API must never be called, so a nil client is safe.
+	orgName, isAE, aeDetermined, err := resolveCreateOrgName(context.Background(), nil, "my-org", true)
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-org", orgName)
+	assert.False(t, isAE)
+	assert.False(t, aeDetermined, "AE determination is deferred to the caller for App auth")
+}
+
+func TestResolveCreateOrgName_PAT_OwnerIsAuthenticatedUser(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v3/user":
+			user := github.User{Login: github.String("monalisa")}
+			b, _ := json.Marshal(user)
+			_, _ = w.Write(b)
+		default:
+			t.Errorf("unexpected request to %s", r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server.URL)
+
+	orgName, _, aeDetermined, err := resolveCreateOrgName(context.Background(), client, "monalisa", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", orgName, "repo should be created under the authenticated user's account")
+	assert.True(t, aeDetermined)
+}
+
+func TestResolveCreateOrgName_PAT_OwnerIsOrg(t *testing.T) {
+	createOrgCalled := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/user":
+			user := github.User{Login: github.String("monalisa")}
+			b, _ := json.Marshal(user)
+			_, _ = w.Write(b)
+		case r.URL.Path == "/api/v3/admin/organizations" && r.Method == http.MethodPost:
+			createOrgCalled = true
+			org := github.Organization{Login: github.String("my-org")}
+			b, _ := json.Marshal(org)
+			_, _ = w.Write(b)
+		default:
+			t.Errorf("unexpected request to %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server.URL)
+
+	orgName, _, aeDetermined, err := resolveCreateOrgName(context.Background(), client, "my-org", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "my-org", orgName)
+	assert.True(t, aeDetermined)
+	assert.True(t, createOrgCalled, "expected org creation to be attempted")
+}
+
+func TestResolveCreateOrgName_PAT_GitHubAE(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/user" {
+			w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
+			user := github.User{Login: github.String("monalisa")}
+			b, _ := json.Marshal(user)
+			_, _ = w.Write(b)
+			return
+		}
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server.URL)
+
+	orgName, isAE, aeDetermined, err := resolveCreateOrgName(context.Background(), client, "monalisa", false)
+
+	require.NoError(t, err)
+	assert.Equal(t, "", orgName)
+	assert.True(t, isAE, "AE should be detected from the user response header")
+	assert.True(t, aeDetermined)
+}
+
+func TestResolveCreateOrgName_PAT_UserError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Simulate a ghs_* token hitting the user API: no user context available.
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server.URL)
+
+	orgName, _, _, err := resolveCreateOrgName(context.Background(), client, "my-org", false)
+
+	require.Error(t, err)
+	assert.Equal(t, "", orgName)
+	assert.Contains(t, err.Error(), "--github-app-auth", "error should hint at GitHub App auth flag")
 }

--- a/src/push_test.go
+++ b/src/push_test.go
@@ -335,6 +335,20 @@ func TestPushOnlyFlags_GitHubAppAuth_Valid(t *testing.T) {
 	}
 }
 
+func TestPushOnlyFlags_GitHubAppAuth_RejectsImpersonation(t *testing.T) {
+	flags := PushOnlyFlags{
+		BaseURL:          "https://example.com",
+		Token:            "ghs_token",
+		GitHubApp:        true,
+		ActionsAdminUser: "actions-admin",
+	}
+
+	validations := flags.Validate()
+
+	require.NotEmpty(t, validations)
+	require.Contains(t, validations.Error().Error(), "--github-app-auth cannot be used with --actions-admin-user")
+}
+
 // Tests for resolveCreateOrgName
 
 func TestResolveCreateOrgName_GitHubApp(t *testing.T) {

--- a/src/push_test.go
+++ b/src/push_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-git/go-git/v5"
@@ -517,6 +519,27 @@ func TestResolveCreateOrgName_PAT_GitHubAE(t *testing.T) {
 	assert.True(t, aeDetermined)
 }
 
+func TestResolveCreateOrgName_PAT_NilLogin(t *testing.T) {
+	// Regression: a user response with no login must produce a clear error.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/v3/user" {
+			_, _ = w.Write([]byte(`{}`))
+			return
+		}
+		t.Errorf("unexpected request to %s", r.URL.Path)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := newTestGitHubClient(t, server.URL)
+
+	orgName, _, _, err := resolveCreateOrgName(context.Background(), client, "my-org", false)
+
+	require.Error(t, err)
+	assert.Equal(t, "", orgName)
+	assert.Contains(t, err.Error(), "login name")
+}
+
 func TestResolveCreateOrgName_PAT_UserError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Simulate a ghs_* token hitting the user API: no user context available.
@@ -532,4 +555,296 @@ func TestResolveCreateOrgName_PAT_UserError(t *testing.T) {
 	require.Error(t, err)
 	assert.Equal(t, "", orgName)
 	assert.Contains(t, err.Error(), "--github-app-auth", "error should hint at GitHub App auth flag")
+}
+
+// fakeGitHub is a configurable mock of the GitHub REST API exercised by
+// getOrCreateGitHubRepo. It records which endpoints were hit so tests can assert
+// on the resulting behaviour (e.g. that App auth never calls /user and that
+// repositories are created under the expected owner with the expected visibility).
+type fakeGitHub struct {
+	// config
+	userLogin         string // login returned by GET /user
+	userAE            bool   // set the AE version header on the GET /user response
+	userStatus        int    // override GET /user status (0 => 200)
+	repoExists        bool   // GET /repos/{owner}/{repo} returns 200 vs 404
+	repoGetAE         bool   // set the AE version header on the GET /repos response
+	repoGetStatus     int    // override GET /repos status (0 => derived from repoExists)
+	createRepoStatus  int    // override POST repos status (0 => 201 Created)
+	orgCreateConflict bool   // POST /admin/organizations returns 422 (already exists)
+	orgGetExists      bool   // GET /orgs/{org} returns 200 (used as create fallback)
+
+	// recorded
+	userCalled       bool
+	created          bool
+	createdUnderUser bool
+	createdOrg       string
+	createdName      string
+	createdVis       string
+	createOrgCalled  bool
+	orgGetCalled     bool
+}
+
+func (f *fakeGitHub) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/user" && r.Method == http.MethodGet:
+			f.userCalled = true
+			if f.userStatus != 0 {
+				w.WriteHeader(f.userStatus)
+				_, _ = w.Write([]byte(`{"message":"no user context"}`))
+				return
+			}
+			if f.userAE {
+				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
+			}
+			login := f.userLogin
+			b, _ := json.Marshal(github.User{Login: &login})
+			_, _ = w.Write(b)
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/repos/") && r.Method == http.MethodGet:
+			parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/v3/repos/"), "/")
+			owner, repo := parts[0], parts[1]
+			status := f.repoGetStatus
+			if status == 0 {
+				if f.repoExists {
+					status = http.StatusOK
+				} else {
+					status = http.StatusNotFound
+				}
+			}
+			if f.repoGetAE {
+				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
+			}
+			if status == http.StatusOK {
+				cloneURL := "https://example.com/" + owner + "/" + repo + ".git"
+				b, _ := json.Marshal(github.Repository{Name: github.String(repo), CloneURL: &cloneURL})
+				_, _ = w.Write(b)
+				return
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"message":"not found"}`))
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && strings.HasSuffix(r.URL.Path, "/repos") && r.Method == http.MethodPost:
+			org := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/"), "/repos")
+			f.createdOrg = org
+			f.recordCreate(r, w, org)
+
+		case r.URL.Path == "/api/v3/user/repos" && r.Method == http.MethodPost:
+			f.createdUnderUser = true
+			f.recordCreate(r, w, "")
+
+		case r.URL.Path == "/api/v3/admin/organizations" && r.Method == http.MethodPost:
+			f.createOrgCalled = true
+			if f.orgCreateConflict {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"message":"Organization already exists"}`))
+				return
+			}
+			var body struct {
+				Login string `json:"login"`
+			}
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &body)
+			b, _ := json.Marshal(github.Organization{Login: github.String(body.Login)})
+			_, _ = w.Write(b)
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && r.Method == http.MethodGet:
+			f.orgGetCalled = true
+			org := strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/")
+			if !f.orgGetExists {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"not found"}`))
+				return
+			}
+			b, _ := json.Marshal(github.Organization{Login: github.String(org)})
+			_, _ = w.Write(b)
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+func (f *fakeGitHub) recordCreate(r *http.Request, w http.ResponseWriter, org string) {
+	f.created = true
+	var body struct {
+		Name       string `json:"name"`
+		Visibility string `json:"visibility"`
+	}
+	data, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(data, &body)
+	f.createdName = body.Name
+	f.createdVis = body.Visibility
+	if f.createRepoStatus != 0 {
+		w.WriteHeader(f.createRepoStatus)
+		_, _ = w.Write([]byte(`{"message":"validation failed"}`))
+		return
+	}
+	cloneURL := "https://example.com/" + org + "/" + body.Name + ".git"
+	w.WriteHeader(http.StatusCreated)
+	b, _ := json.Marshal(github.Repository{Name: github.String(body.Name), CloneURL: &cloneURL})
+	_, _ = w.Write(b)
+}
+
+func (f *fakeGitHub) start(t *testing.T) *github.Client {
+	t.Helper()
+	server := httptest.NewServer(f.handler(t))
+	t.Cleanup(server.Close)
+	return newTestGitHubClient(t, server.URL)
+}
+
+// Tests for getOrCreateGitHubRepo with GitHub App auth (new behaviour)
+
+func TestGetOrCreateGitHubRepo_GitHubApp_CreatesUnderOrg(t *testing.T) {
+	f := &fakeGitHub{repoExists: false}
+	client := f.start(t)
+
+	repo, err := getOrCreateGitHubRepo(context.Background(), client, "my-repo", "my-org", true)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.Equal(t, "my-repo", repo.GetName())
+	assert.False(t, f.userCalled, "App auth must not call the user API")
+	assert.True(t, f.created, "missing repo should be created")
+	assert.False(t, f.createdUnderUser, "App auth must create under the org, not a user account")
+	assert.Equal(t, "my-org", f.createdOrg, "repo should be created under the owner from the repo name")
+	assert.Equal(t, "public", f.createdVis)
+}
+
+func TestGetOrCreateGitHubRepo_GitHubApp_ExistingRepo(t *testing.T) {
+	f := &fakeGitHub{repoExists: true}
+	client := f.start(t)
+
+	repo, err := getOrCreateGitHubRepo(context.Background(), client, "existing-repo", "my-org", true)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.False(t, f.userCalled, "App auth must not call the user API")
+	assert.False(t, f.created, "existing repo must not be recreated")
+}
+
+func TestGetOrCreateGitHubRepo_GitHubApp_GHAE_InternalVisibility(t *testing.T) {
+	// With App auth the AE version is detected from the repo response header,
+	// not the user response, so internal visibility must still be selected.
+	f := &fakeGitHub{repoExists: false, repoGetAE: true}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "ghae-repo", "my-org", true)
+
+	require.NoError(t, err)
+	assert.False(t, f.userCalled, "App auth must not call the user API")
+	assert.True(t, f.created)
+	assert.Equal(t, "internal", f.createdVis, "AE detected from the repo response should yield internal visibility")
+}
+
+// Regression tests for getOrCreateGitHubRepo with PAT auth (pre-existing
+// behaviour). These had no unit coverage before; they guard against regressions
+// from the App-auth refactor.
+
+func TestGetOrCreateGitHubRepo_PAT_ExistingRepo(t *testing.T) {
+	f := &fakeGitHub{repoExists: true, userLogin: "monalisa"}
+	client := f.start(t)
+
+	repo, err := getOrCreateGitHubRepo(context.Background(), client, "existing-repo", "monalisa", false)
+
+	require.NoError(t, err)
+	require.NotNil(t, repo)
+	assert.True(t, f.userCalled, "PAT auth resolves the authenticated user")
+	assert.False(t, f.created, "existing repo must not be recreated")
+}
+
+func TestGetOrCreateGitHubRepo_PAT_CreatesUnderUser(t *testing.T) {
+	f := &fakeGitHub{repoExists: false, userLogin: "monalisa"}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "new-repo", "monalisa", false)
+
+	require.NoError(t, err)
+	assert.True(t, f.created)
+	assert.True(t, f.createdUnderUser, "owner matching the authenticated user must create under the user account")
+	assert.False(t, f.createOrgCalled, "no org should be created when owner is the authenticated user")
+	assert.Equal(t, "public", f.createdVis)
+}
+
+func TestGetOrCreateGitHubRepo_PAT_CreatesUnderOrg(t *testing.T) {
+	f := &fakeGitHub{repoExists: false, userLogin: "monalisa"}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "new-repo", "my-org", false)
+
+	require.NoError(t, err)
+	assert.True(t, f.createOrgCalled, "owner differing from the authenticated user must ensure the org exists")
+	assert.True(t, f.created)
+	assert.False(t, f.createdUnderUser)
+	assert.Equal(t, "my-org", f.createdOrg)
+}
+
+func TestGetOrCreateGitHubRepo_PAT_GHAE_InternalVisibility(t *testing.T) {
+	// AE detected from the user response (pre-existing behaviour) must still
+	// select internal visibility.
+	f := &fakeGitHub{repoExists: false, userLogin: "monalisa", userAE: true}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "ghae-repo", "monalisa", false)
+
+	require.NoError(t, err)
+	assert.True(t, f.created)
+	assert.Equal(t, "internal", f.createdVis, "AE detected from the user response should yield internal visibility")
+}
+
+func TestGetOrCreateGitHubRepo_PAT_RepoGetError(t *testing.T) {
+	// A non-404 error from the existence check must be surfaced, not swallowed.
+	f := &fakeGitHub{repoGetStatus: http.StatusInternalServerError, userLogin: "monalisa"}
+	client := f.start(t)
+
+	repo, err := getOrCreateGitHubRepo(context.Background(), client, "some-repo", "monalisa", false)
+
+	require.Error(t, err)
+	assert.Nil(t, repo)
+	assert.False(t, f.created, "no repo should be created when the existence check errors")
+}
+
+func TestGetOrCreateGitHubRepo_GitHubApp_UserNeverCalledOnError(t *testing.T) {
+	// Even when repo creation cannot proceed, App auth must never hit /user.
+	f := &fakeGitHub{repoGetStatus: http.StatusInternalServerError}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "some-repo", "my-org", true)
+
+	require.Error(t, err)
+	assert.False(t, f.userCalled, "App auth must not call the user API even on error paths")
+}
+
+func TestGetOrCreateGitHubRepo_CreateFailureIsWrapped(t *testing.T) {
+	// A failed repo creation must surface a wrapped error, not a nil repo.
+	f := &fakeGitHub{repoExists: false, createRepoStatus: http.StatusUnprocessableEntity}
+	client := f.start(t)
+
+	repo, err := getOrCreateGitHubRepo(context.Background(), client, "bad-repo", "my-org", true)
+
+	require.Error(t, err)
+	assert.Nil(t, repo)
+	assert.Contains(t, err.Error(), "error creating repository my-org/bad-repo")
+}
+
+func TestGetOrCreateGitHubRepo_PAT_OrgAlreadyExistsFallback(t *testing.T) {
+	// Regression: when org creation fails because the org already exists, the
+	// code falls back to fetching the org and continues.
+	f := &fakeGitHub{
+		repoExists:        false,
+		userLogin:         "monalisa",
+		orgCreateConflict: true,
+		orgGetExists:      true,
+	}
+	client := f.start(t)
+
+	_, err := getOrCreateGitHubRepo(context.Background(), client, "new-repo", "org-already-exists", false)
+
+	require.NoError(t, err)
+	assert.True(t, f.createOrgCalled, "org creation should be attempted")
+	assert.True(t, f.orgGetCalled, "org should be fetched as a fallback when creation conflicts")
+	assert.True(t, f.created)
+	assert.Equal(t, "org-already-exists", f.createdOrg)
 }

--- a/src/testutils_test.go
+++ b/src/testutils_test.go
@@ -1,0 +1,260 @@
+package src
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/google/go-github/v43/github"
+	"github.com/stretchr/testify/require"
+)
+
+// This file holds test utilities (mocks, fakes and helpers) shared across the
+// package's tests. Keeping them in one place avoids duplication between
+// push_test.go, git_test.go and any future test files.
+
+// mockReferenceIter is an in-memory storer.ReferenceIter over a fixed slice of
+// references.
+type mockReferenceIter struct {
+	refs  []*plumbing.Reference
+	index int
+}
+
+func (m *mockReferenceIter) Next() (*plumbing.Reference, error) {
+	if m.index >= len(m.refs) {
+		return nil, storer.ErrStop
+	}
+	ref := m.refs[m.index]
+	m.index++
+	return ref, nil
+}
+
+func (m *mockReferenceIter) ForEach(fn func(*plumbing.Reference) error) error {
+	for _, ref := range m.refs {
+		if err := fn(ref); err != nil {
+			if err == storer.ErrStop {
+				return nil
+			}
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *mockReferenceIter) Close() {}
+
+// mockGitRepository is a GitRepository test double backed by a fixed set of refs.
+type mockGitRepository struct {
+	refs []*plumbing.Reference
+	err  error
+}
+
+func (m *mockGitRepository) DeleteRemote(name string) error {
+	return nil
+}
+
+func (m *mockGitRepository) CreateRemote(c *config.RemoteConfig) (GitRemote, error) {
+	return nil, nil
+}
+
+func (m *mockGitRepository) FetchContext(ctx context.Context, o *git.FetchOptions) error {
+	return nil
+}
+
+func (m *mockGitRepository) References() (storer.ReferenceIter, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &mockReferenceIter{refs: m.refs, index: 0}, nil
+}
+
+// mockGitRemote is a GitRemote test double that records the refspecs it was
+// asked to push.
+type mockGitRemote struct {
+	pushCalls       [][]config.RefSpec
+	pushError       error
+	alreadyUpToDate bool
+	remoteConfig    *config.RemoteConfig
+}
+
+func (m *mockGitRemote) PushContext(ctx context.Context, o *git.PushOptions) error {
+	m.pushCalls = append(m.pushCalls, o.RefSpecs)
+	if m.alreadyUpToDate {
+		return git.NoErrAlreadyUpToDate
+	}
+	return m.pushError
+}
+
+func (m *mockGitRemote) Config() *config.RemoteConfig {
+	if m.remoteConfig != nil {
+		return m.remoteConfig
+	}
+	return &config.RemoteConfig{Name: "test-remote"}
+}
+
+// createNRefs returns n distinct branch reference names, useful for batching tests.
+func createNRefs(n int) []plumbing.ReferenceName {
+	refs := make([]plumbing.ReferenceName, n)
+	for i := 0; i < n; i++ {
+		refs[i] = plumbing.NewBranchReferenceName(fmt.Sprintf("branch-%d", i))
+	}
+	return refs
+}
+
+// newTestGitHubClient returns a github.Client whose API requests are routed to
+// the provided test server.
+func newTestGitHubClient(t *testing.T, serverURL string) *github.Client {
+	t.Helper()
+	client, err := github.NewEnterpriseClient(serverURL, serverURL, nil)
+	require.NoError(t, err)
+	return client
+}
+
+// fakeGitHub is a configurable mock of the GitHub REST API exercised by
+// getOrCreateGitHubRepo. It records which endpoints were hit so tests can assert
+// on the resulting behaviour (e.g. that App auth never calls /user and that
+// repositories are created under the expected owner with the expected visibility).
+type fakeGitHub struct {
+	// config
+	userLogin         string // login returned by GET /user
+	userAE            bool   // set the AE version header on the GET /user response
+	userStatus        int    // override GET /user status (0 => 200)
+	repoExists        bool   // GET /repos/{owner}/{repo} returns 200 vs 404
+	repoGetAE         bool   // set the AE version header on the GET /repos response
+	repoGetStatus     int    // override GET /repos status (0 => derived from repoExists)
+	createRepoStatus  int    // override POST repos status (0 => 201 Created)
+	orgCreateConflict bool   // POST /admin/organizations returns 422 (already exists)
+	orgGetExists      bool   // GET /orgs/{org} returns 200 (used as create fallback)
+
+	// recorded
+	userCalled       bool
+	created          bool
+	createdUnderUser bool
+	createdOrg       string
+	createdName      string
+	createdVis       string
+	createOrgCalled  bool
+	orgGetCalled     bool
+}
+
+func (f *fakeGitHub) handler(t *testing.T) http.HandlerFunc {
+	t.Helper()
+	return func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/api/v3/user" && r.Method == http.MethodGet:
+			f.userCalled = true
+			if f.userStatus != 0 {
+				w.WriteHeader(f.userStatus)
+				_, _ = w.Write([]byte(`{"message":"no user context"}`))
+				return
+			}
+			if f.userAE {
+				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
+			}
+			login := f.userLogin
+			b, _ := json.Marshal(github.User{Login: &login})
+			_, _ = w.Write(b)
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/repos/") && r.Method == http.MethodGet:
+			parts := strings.Split(strings.TrimPrefix(r.URL.Path, "/api/v3/repos/"), "/")
+			owner, repo := parts[0], parts[1]
+			status := f.repoGetStatus
+			if status == 0 {
+				if f.repoExists {
+					status = http.StatusOK
+				} else {
+					status = http.StatusNotFound
+				}
+			}
+			if f.repoGetAE {
+				w.Header().Set(enterpriseVersionHeaderKey, enterpriseAegisVersionHeaderValue)
+			}
+			if status == http.StatusOK {
+				cloneURL := "https://example.com/" + owner + "/" + repo + ".git"
+				b, _ := json.Marshal(github.Repository{Name: github.String(repo), CloneURL: &cloneURL})
+				_, _ = w.Write(b)
+				return
+			}
+			w.WriteHeader(status)
+			_, _ = w.Write([]byte(`{"message":"not found"}`))
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && strings.HasSuffix(r.URL.Path, "/repos") && r.Method == http.MethodPost:
+			org := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/"), "/repos")
+			f.createdOrg = org
+			f.recordCreate(r, w, org)
+
+		case r.URL.Path == "/api/v3/user/repos" && r.Method == http.MethodPost:
+			f.createdUnderUser = true
+			f.recordCreate(r, w, "")
+
+		case r.URL.Path == "/api/v3/admin/organizations" && r.Method == http.MethodPost:
+			f.createOrgCalled = true
+			if f.orgCreateConflict {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = w.Write([]byte(`{"message":"Organization already exists"}`))
+				return
+			}
+			var body struct {
+				Login string `json:"login"`
+			}
+			data, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(data, &body)
+			b, _ := json.Marshal(github.Organization{Login: github.String(body.Login)})
+			_, _ = w.Write(b)
+
+		case strings.HasPrefix(r.URL.Path, "/api/v3/orgs/") && r.Method == http.MethodGet:
+			f.orgGetCalled = true
+			org := strings.TrimPrefix(r.URL.Path, "/api/v3/orgs/")
+			if !f.orgGetExists {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(`{"message":"not found"}`))
+				return
+			}
+			b, _ := json.Marshal(github.Organization{Login: github.String(org)})
+			_, _ = w.Write(b)
+
+		default:
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}
+}
+
+func (f *fakeGitHub) recordCreate(r *http.Request, w http.ResponseWriter, org string) {
+	f.created = true
+	var body struct {
+		Name       string `json:"name"`
+		Visibility string `json:"visibility"`
+	}
+	data, _ := io.ReadAll(r.Body)
+	_ = json.Unmarshal(data, &body)
+	f.createdName = body.Name
+	f.createdVis = body.Visibility
+	if f.createRepoStatus != 0 {
+		w.WriteHeader(f.createRepoStatus)
+		_, _ = w.Write([]byte(`{"message":"validation failed"}`))
+		return
+	}
+	cloneURL := "https://example.com/" + org + "/" + body.Name + ".git"
+	w.WriteHeader(http.StatusCreated)
+	b, _ := json.Marshal(github.Repository{Name: github.String(body.Name), CloneURL: &cloneURL})
+	_, _ = w.Write(b)
+}
+
+// start launches an httptest server backed by the fake and returns a github
+// client pointed at it. The server is closed automatically when the test ends.
+func (f *fakeGitHub) start(t *testing.T) *github.Client {
+	t.Helper()
+	server := httptest.NewServer(f.handler(t))
+	t.Cleanup(server.Close)
+	return newTestGitHubClient(t, server.URL)
+}

--- a/test/github.go
+++ b/test/github.go
@@ -38,6 +38,16 @@ func main() {
 
 	r.HandleFunc("/api/v3/user", func(w http.ResponseWriter, r *http.Request) {
 		token := r.Header.Get("Authorization")
+		// GitHub App installation tokens (ghs_*) have no user context; the user
+		// API returns 403. With --github-app-auth this endpoint should never be hit.
+		if strings.Contains(token, "ghs_") {
+			w.WriteHeader(http.StatusForbidden)
+			_, err := w.Write([]byte(`{"message":"Resource not accessible by integration"}`))
+			if err != nil {
+				panic(err)
+			}
+			return
+		}
 		if strings.Contains(token, "ghaetoken") {
 			w.Header().Set("x-github-enterprise-version", "GitHub AE")
 		}


### PR DESCRIPTION
# Add GitHub App installation token authentication for `push`/`sync`

## Motivation

It is currently not possible to authenticate `actions-sync` with a GitHub App installation token (`ghs_*`); the `push`/`sync` flow calls `GET /user`, which App installation tokens cannot use (they have no user context and receive `403 Resource not accessible by integration`). Users who want to avoid long-lived personal access tokens are therefore blocked. This revives the GitHub App authentication portion of #158.

## What this does

- Adds a `--github-app-auth` flag to `push` and `sync`. When set, the `GET /user` call is skipped and the destination repository is created under the owner taken from the destination repo name via `POST /orgs/{owner}/repos`.
- Falls back to the repository response header to detect GitHub AE when creating a new repo, since the version can no longer be read from the user response under App auth.
- Uses `x-access-token` as the git basic-auth username for the push, matching GitHub's documented convention for App installation tokens.
- Adds unit tests covering both the new App-auth path and the existing PAT path (regression), plus an integration test in `script/test-build` that pushes with a `ghs_*` token; the test server now returns `403` on `/api/v3/user` for `ghs_*` tokens so the test fails if `/user` is ever hit.
- Extracts the shared test mocks/fakes into a `testutils_test.go` helper.
- Documents the flag and a dedicated "GitHub App authentication" section in the README.

## Scope

This intentionally covers only the GitHub App authentication part of #158. The description-syncing and `keep-description` changes from that PR are out of scope here.

## Constraints / behavior notes

- The destination owner must be a pre-existing organization that the App is installed on. Installation tokens cannot create user-owned repositories (`POST /user/repos` requires user context that App tokens lack), so a user-account installation will not work. This was verified empirically against a real GHES instance.
- Organization auto-creation and user impersonation (`--actions-admin-user`) rely on user/site-admin context and are not used under App auth.
- The change is fully gated behind `--github-app-auth` (default `false`); the existing PAT code path is unchanged.

## Required App permissions

`Administration: Read & write` (create repositories), `Contents: Read & write`, `Metadata: Read-only`, and `Workflows: Read & write` if synced repositories contain workflow files.

## Validation

Validated end-to-end against a real GitHub Enterprise Server 3.21.1 instance:

- A `ghs_*` installation token returns `403` on `/api/v3/user`, confirming the need to skip that call.
- `push --github-app-auth` created the repository under the target org and pushed all refs; destination branch SHAs matched the source exactly.
- A second push correctly detected the existing repository and re-synced (idempotent).
- A user-account installation token was confirmed unable to create repositories (`POST /user/repos` returns `403`), confirming the org-owner requirement.

`go build`, `go vet`, `go test`, and `gofmt` are clean.
