### PR TITLE
feat: add --source-token for authenticating private repo pulls

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ When there are machines which have access to both the public internet and the GH
    The URL of the GHES instance to sync repositories onto.
 - `destination-token` _(required)_
    A personal access token to authenticate against the GHES instance when uploading repositories. See [Destination token scopes](#destination-token-scopes) below.
+- `source-token` _(optional)_
+   A token used to authenticate against the source when pulling private repositories. For a personal access token, the `repo` scope (read access to the source repositories) is sufficient. For a GitHub App installation token (`ghs_*`), the installation needs read access to the source repositories' contents; App tokens use installation permissions, not OAuth scopes. Must be used with an `https://` `source-url`.
 - `repo-name` _(optional)_
    A single repository to be synced. In the format of `owner/repo`. Optionally if you wish the repository to be named different on your GHES instance you can provide an alias in the format: `upstream_owner/upstream_repo:destination_owner/destination_repo`
 - `repo-name-list` _(optional)_
@@ -87,6 +89,8 @@ When no machine has access to both the public internet and the GHES instance:
 
 - `cache-dir` _(required)_
    The directory to cache the pulled repositories into.
+- `source-token` _(optional)_
+   A token used to authenticate against the source when pulling private repositories. For a personal access token, the `repo` scope (read access to the source repositories) is sufficient. For a GitHub App installation token (`ghs_*`), the installation needs read access to the source repositories' contents; App tokens use installation permissions, not OAuth scopes. Must be used with an `https://` `source-url`.
 - `repo-name` _(optional)_
    A single repository to be synced. In the format of `owner/repo`. Optionally if you wish the repository to be named different on your GHES instance you can provide an alias in the format: `upstream_owner/upstream_repo:destination_owner/destination_repo`
 - `repo-name-list` _(optional)_

--- a/src/pull.go
+++ b/src/pull.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing/transport"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
 	"github.com/spf13/cobra"
 )
 
 type PullOnlyFlags struct {
-	SourceURL string
+	SourceURL, Token string
 }
 
 type PullFlags struct {
@@ -28,6 +30,7 @@ func (f *PullFlags) Init(cmd *cobra.Command) {
 
 func (f *PullOnlyFlags) Init(cmd *cobra.Command) {
 	cmd.Flags().StringVar(&f.SourceURL, "source-url", "https://github.com", "The domain to pull from")
+	cmd.Flags().StringVar(&f.Token, "source-token", "", "Token used to authenticate against the source when pulling private repositories. Works with a personal access token or a GitHub App installation token (ghs_*).")
 }
 
 func (f *PullFlags) Validate() Validations {
@@ -36,7 +39,22 @@ func (f *PullFlags) Validate() Validations {
 
 func (f *PullOnlyFlags) Validate() Validations {
 	var validations Validations
+	if f.Token != "" && !strings.HasPrefix(strings.ToLower(f.SourceURL), "https://") {
+		validations = append(validations, "--source-token requires an https:// --source-url so the token is sent over a secure transport")
+	}
 	return validations
+}
+
+// gitAuthMethod returns a BasicAuth transport for the given token, or nil when
+// no token is set (anonymous access).
+func gitAuthMethod(token string) transport.AuthMethod {
+	if token == "" {
+		return nil
+	}
+	return &http.BasicAuth{
+		Username: "x-access-token",
+		Password: token,
+	}
 }
 
 func Pull(ctx context.Context, flags *PullFlags) error {
@@ -45,19 +63,19 @@ func Pull(ctx context.Context, flags *PullFlags) error {
 		return err
 	}
 
-	return PullManyWithGitImpl(ctx, flags.SourceURL, flags.CacheDir, repoNames, gitImplementation{})
+	return PullManyWithGitImpl(ctx, flags.SourceURL, gitAuthMethod(flags.Token), flags.CacheDir, repoNames, gitImplementation{})
 }
 
-func PullManyWithGitImpl(ctx context.Context, sourceURL, cacheDir string, repoNames []string, gitimpl GitImplementation) error {
+func PullManyWithGitImpl(ctx context.Context, sourceURL string, auth transport.AuthMethod, cacheDir string, repoNames []string, gitimpl GitImplementation) error {
 	for _, repoName := range repoNames {
-		if err := PullWithGitImpl(ctx, sourceURL, cacheDir, repoName, gitimpl); err != nil {
+		if err := PullWithGitImpl(ctx, sourceURL, auth, cacheDir, repoName, gitimpl); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func PullWithGitImpl(ctx context.Context, sourceURL, cacheDir string, repoName string, gitimpl GitImplementation) error {
+func PullWithGitImpl(ctx context.Context, sourceURL string, auth transport.AuthMethod, cacheDir string, repoName string, gitimpl GitImplementation) error {
 	originRepoName, destRepoName, err := extractSourceDest(repoName)
 	if err != nil {
 		return err
@@ -75,6 +93,7 @@ func PullWithGitImpl(ctx context.Context, sourceURL, cacheDir string, repoName s
 		_, err := gitimpl.CloneRepository(dst, &git.CloneOptions{
 			SingleBranch: false,
 			URL:          fmt.Sprintf("%s/%s", sourceURL, originRepoName),
+			Auth:         auth,
 		})
 		if err != nil {
 			if strings.Contains(err.Error(), "authentication required") {
@@ -94,9 +113,13 @@ func PullWithGitImpl(ctx context.Context, sourceURL, cacheDir string, repoName s
 		RefSpecs: []config.RefSpec{
 			config.RefSpec("+refs/heads/*:refs/heads/*"),
 		},
+		Auth: auth,
 		Tags: git.AllTags,
 	})
 	if err != nil && err != git.NoErrAlreadyUpToDate {
+		if strings.Contains(err.Error(), "authentication required") {
+			return fmt.Errorf("could not fetch %s, the repository may require authentication or does not exist", originRepoName)
+		}
 		return err
 	}
 

--- a/src/pull_test.go
+++ b/src/pull_test.go
@@ -1,0 +1,139 @@
+package src
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitAuthMethod_EmptyTokenIsAnonymous(t *testing.T) {
+	assert.Nil(t, gitAuthMethod(""))
+}
+
+func TestGitAuthMethod_TokenBuildsBasicAuth(t *testing.T) {
+	auth := gitAuthMethod("ghs_exampletoken")
+	basic, ok := auth.(*http.BasicAuth)
+	require.True(t, ok, "expected BasicAuth")
+	assert.Equal(t, "x-access-token", basic.Username)
+	assert.Equal(t, "ghs_exampletoken", basic.Password)
+}
+
+func TestPullOnlyFlags_Validate_TokenOverHTTPRejected(t *testing.T) {
+	f := &PullOnlyFlags{SourceURL: "http://insecure.example.com", Token: "secret"}
+	validations := f.Validate()
+	require.Len(t, validations, 1)
+	assert.Contains(t, validations[0], "--source-token")
+}
+
+func TestPullOnlyFlags_Validate_TokenOverHTTPSAllowed(t *testing.T) {
+	f := &PullOnlyFlags{SourceURL: "https://github.com", Token: "secret"}
+	assert.Empty(t, f.Validate())
+}
+
+func TestPullOnlyFlags_Validate_TokenOverHTTPCaseInsensitiveRejected(t *testing.T) {
+	for _, sourceURL := range []string{"HTTP://insecure.example.com", "Http://insecure.example.com"} {
+		f := &PullOnlyFlags{SourceURL: sourceURL, Token: "secret"}
+		assert.Len(t, f.Validate(), 1, sourceURL)
+	}
+}
+
+func TestPullOnlyFlags_Validate_TokenRequiresHTTPS(t *testing.T) {
+	for _, sourceURL := range []string{"ssh://git@example.com", "git://example.com", "example.com"} {
+		f := &PullOnlyFlags{SourceURL: sourceURL, Token: "secret"}
+		assert.Len(t, f.Validate(), 1, sourceURL)
+	}
+}
+
+func TestPullOnlyFlags_Validate_TokenOverHTTPSCaseInsensitiveAllowed(t *testing.T) {
+	f := &PullOnlyFlags{SourceURL: "HTTPS://github.com", Token: "secret"}
+	assert.Empty(t, f.Validate())
+}
+
+func TestPullOnlyFlags_Validate_NoTokenAllowsHTTP(t *testing.T) {
+	f := &PullOnlyFlags{SourceURL: "http://insecure.example.com"}
+	assert.Empty(t, f.Validate())
+}
+
+func TestPullWithGitImpl_ThreadsAuthToCloneAndFetch(t *testing.T) {
+	cacheDir := t.TempDir()
+	repo := &fakePullRepo{}
+	impl := &fakePullGitImpl{repo: repo}
+	auth := gitAuthMethod("secret-token")
+
+	err := PullWithGitImpl(context.Background(), "https://github.com", auth, cacheDir, "actions/setup-node", impl)
+	require.NoError(t, err)
+
+	assert.Same(t, auth, impl.cloneAuth, "clone should use the provided auth")
+	assert.True(t, repo.fetchCalled)
+	assert.Same(t, auth, repo.fetchAuth, "fetch should use the provided auth")
+}
+
+func TestPullWithGitImpl_NilAuthWhenNoToken(t *testing.T) {
+	cacheDir := t.TempDir()
+	repo := &fakePullRepo{}
+	impl := &fakePullGitImpl{repo: repo}
+
+	err := PullWithGitImpl(context.Background(), "https://github.com", nil, cacheDir, "actions/setup-node", impl)
+	require.NoError(t, err)
+
+	assert.Nil(t, impl.cloneAuth)
+	assert.Nil(t, repo.fetchAuth)
+}
+
+func TestPullWithGitImpl_SkipsCloneWhenRepositoryExists(t *testing.T) {
+	cacheDir := t.TempDir()
+	repo := &fakePullRepo{}
+	impl := &fakePullGitImpl{repo: repo, exists: true}
+	auth := gitAuthMethod("secret-token")
+
+	err := PullWithGitImpl(context.Background(), "https://github.com", auth, cacheDir, "actions/setup-node", impl)
+	require.NoError(t, err)
+
+	assert.Nil(t, impl.cloneAuth, "clone should be skipped when the repo already exists")
+	assert.Same(t, auth, repo.fetchAuth, "fetch should still authenticate")
+}
+
+func TestPullWithGitImpl_AuthRequiredReturnsFriendlyError(t *testing.T) {
+	cacheDir := t.TempDir()
+	impl := &fakePullGitImpl{repo: &fakePullRepo{}, cloneErr: errors.New("authentication required")}
+
+	err := PullWithGitImpl(context.Background(), "https://github.com", nil, cacheDir, "actions/private", impl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may require authentication or does not exist")
+}
+
+func TestPullWithGitImpl_FetchAuthRequiredReturnsFriendlyError(t *testing.T) {
+	cacheDir := t.TempDir()
+	repo := &fakePullRepo{fetchErr: errors.New("authentication required")}
+	impl := &fakePullGitImpl{repo: repo, exists: true}
+
+	err := PullWithGitImpl(context.Background(), "https://github.com", nil, cacheDir, "actions/private", impl)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "may require authentication or does not exist")
+}
+
+func TestPullManyWithGitImpl_ThreadsAuthToEachRepo(t *testing.T) {
+	cacheDir := t.TempDir()
+	impl := &fakePullGitImpl{repo: &fakePullRepo{}}
+	auth := gitAuthMethod("secret-token")
+
+	err := PullManyWithGitImpl(context.Background(), "https://github.com", auth, cacheDir, []string{"actions/a", "actions/b"}, impl)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, impl.cloneCount, "each repo should be cloned")
+	assert.Same(t, auth, impl.cloneAuth, "clone should use the provided auth")
+	assert.Same(t, auth, impl.repo.fetchAuth, "fetch should use the provided auth")
+}
+
+func TestPullManyWithGitImpl_StopsOnFirstError(t *testing.T) {
+	cacheDir := t.TempDir()
+	impl := &fakePullGitImpl{repo: &fakePullRepo{}, cloneErr: errors.New("boom")}
+
+	err := PullManyWithGitImpl(context.Background(), "https://github.com", nil, cacheDir, []string{"actions/a", "actions/b"}, impl)
+	require.Error(t, err)
+	assert.Equal(t, 1, impl.cloneCount, "iteration should stop after the first failing repo")
+}

--- a/src/testutils_test.go
+++ b/src/testutils_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/storer"
+	"github.com/go-git/go-git/v5/plumbing/transport"
 	"github.com/google/go-github/v43/github"
 	"github.com/stretchr/testify/require"
 )
@@ -99,6 +100,54 @@ func (m *mockGitRemote) Config() *config.RemoteConfig {
 		return m.remoteConfig
 	}
 	return &config.RemoteConfig{Name: "test-remote"}
+}
+
+// fakePullGitImpl is a GitImplementation test double that records the auth
+// handed to clone/fetch so tests can assert the source token is threaded all
+// the way down to git operations. cloneErr, when set, makes CloneRepository
+// fail so error paths can be exercised.
+type fakePullGitImpl struct {
+	exists     bool
+	repo       *fakePullRepo
+	cloneAuth  transport.AuthMethod
+	cloneCount int
+	cloneErr   error
+}
+
+func (f *fakePullGitImpl) NewGitRepository(dir string) (GitRepository, error) {
+	return f.repo, nil
+}
+
+func (f *fakePullGitImpl) CloneRepository(dir string, o *git.CloneOptions) (GitRepository, error) {
+	f.cloneAuth = o.Auth
+	f.cloneCount++
+	if f.cloneErr != nil {
+		return nil, f.cloneErr
+	}
+	return f.repo, nil
+}
+
+func (f *fakePullGitImpl) RepositoryExists(dir string) bool {
+	return f.exists
+}
+
+// fakePullRepo is a GitRepository test double that records the auth used on
+// FetchContext. fetchErr, when set, makes FetchContext fail so error paths can
+// be exercised.
+type fakePullRepo struct {
+	fetchAuth   transport.AuthMethod
+	fetchCalled bool
+	fetchErr    error
+}
+
+func (r *fakePullRepo) DeleteRemote(string) error                            { return nil }
+func (r *fakePullRepo) CreateRemote(*config.RemoteConfig) (GitRemote, error) { return nil, nil }
+func (r *fakePullRepo) References() (storer.ReferenceIter, error)            { return nil, nil }
+
+func (r *fakePullRepo) FetchContext(ctx context.Context, o *git.FetchOptions) error {
+	r.fetchCalled = true
+	r.fetchAuth = o.Auth
+	return r.fetchErr
 }
 
 // createNRefs returns n distinct branch reference names, useful for batching tests.


### PR DESCRIPTION
## What

Adds a `--source-token` flag to `actions-sync pull` (and `sync`) so private repositories can be pulled from the source instance. Without it, pulling a private repo fails because the clone/fetch is unauthenticated. Inspired by <https://github.com/actions/actions-sync/pull/162>.

## Why

`actions-sync` could only pull public repositories. Customers mirroring **private** actions from a source GitHub instance had no way to authenticate the pull. This flag accepts a personal access token or a GitHub App installation token (`ghs_*`) and uses it for the underlying git clone/fetch.

## Changes

- Add `--source-token` flag to the pull/sync commands, threaded as a typed `transport.AuthMethod` (built once at the entrypoint; `nil` means anonymous, preserving existing behavior).
- Use basic auth with username `x-access-token` so both PATs and App installation tokens work.
- Reject `--source-token` when `--source-url` is insecure `http://` (case-insensitive), so the token is never sent in cleartext.
- Unit tests for the auth helper, validation, auth threading through clone/fetch, the multi-repo loop, and the auth-required error translation. Shared test doubles live in `testutils_test.go`.
- README documentation for the new flag in the sync and pull sections.

## Testing

- `go build`, `go vet`, `gofmt`, and `go test ./src/...` all pass.
- Validated end-to-end against a real GHES 3.21.1 instance using the instance as the source:
  - Pulling a private repo **without** the token fails with an authentication error.
  - Pulling the same private repo **with** a `ghs_` installation token succeeds and fetches all refs.
  - Supplying the token over `http://` is rejected before any network call.
